### PR TITLE
Introduis la notion de `MessageRecu`

### DIFF
--- a/src/adaptateurs/adaptateurDomibus.js
+++ b/src/adaptateurs/adaptateurDomibus.js
@@ -139,7 +139,7 @@ const AdaptateurDomibus = (config = {}) => {
       annonceur.on(REPONSE_REDIRECTION_PREVISUALISATION, (reponse) => {
         if (idConversation === reponse.idConversation()) {
           try {
-            resolve(reponse.urlRedirection());
+            resolve(reponse.suiteConversation());
           } catch (e) {
             reject(e);
           }

--- a/src/domibus/fabriqueMessages.js
+++ b/src/domibus/fabriqueMessages.js
@@ -1,0 +1,26 @@
+const ReponseErreur = require('./reponseErreur');
+const ReponseErreurAutorisationRequise = require('./reponseErreurAutorisationRequise');
+const ReponseSucces = require('./reponseSucces');
+const Requete = require('./requete');
+const Entete = require('../ebms/entete');
+
+const estReponseErreurAutorisationRequise = (xml) => (
+  xml.QueryResponse['@_status'] === 'urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Failure'
+    && xml.QueryResponse.Exception['@_type'] === 'rs:AuthorizationExceptionType'
+);
+
+const nouveauMessage = (action, corpsMessage) => {
+  if (action === Entete.EXECUTION_REQUETE) {
+    return new Requete(corpsMessage);
+  }
+
+  if (action === Entete.EXECUTION_REPONSE) {
+    return new ReponseSucces(corpsMessage);
+  }
+
+  return estReponseErreurAutorisationRequise(corpsMessage)
+    ? new ReponseErreurAutorisationRequise(corpsMessage)
+    : new ReponseErreur(corpsMessage);
+};
+
+module.exports = { nouveauMessage };

--- a/src/domibus/messageRecu.js
+++ b/src/domibus/messageRecu.js
@@ -1,0 +1,7 @@
+class MessageRecu {
+  constructor(xmlParse) {
+    this.xmlParse = xmlParse;
+  }
+}
+
+module.exports = MessageRecu;

--- a/src/domibus/reponseErreur.js
+++ b/src/domibus/reponseErreur.js
@@ -1,0 +1,11 @@
+const MessageRecu = require('./messageRecu');
+const { ErreurReponseRequete } = require('../erreurs');
+
+class ReponseErreur extends MessageRecu {
+  suiteConversation() {
+    const messageErreur = this.xmlParse.QueryResponse.Exception['@_message'];
+    throw new ErreurReponseRequete(messageErreur);
+  }
+}
+
+module.exports = ReponseErreur;

--- a/src/domibus/reponseErreurAutorisationRequise.js
+++ b/src/domibus/reponseErreurAutorisationRequise.js
@@ -1,0 +1,10 @@
+const MessageRecu = require('./messageRecu');
+
+class ReponseErreurAutorisationRequise extends MessageRecu {
+  suiteConversation() {
+    return this.xmlParse.QueryResponse.Exception.Slot
+      .find((slot) => slot['@_name'] === 'PreviewLocation').SlotValue.Value;
+  }
+}
+
+module.exports = ReponseErreurAutorisationRequise;

--- a/src/domibus/reponseSucces.js
+++ b/src/domibus/reponseSucces.js
@@ -1,0 +1,6 @@
+const MessageRecu = require('./messageRecu');
+
+class ReponseSucces extends MessageRecu {
+}
+
+module.exports = ReponseSucces;

--- a/src/domibus/requete.js
+++ b/src/domibus/requete.js
@@ -1,0 +1,6 @@
+const MessageRecu = require('./messageRecu');
+
+class Requete extends MessageRecu {
+}
+
+module.exports = Requete;

--- a/test/domibus/fabriqueMessages.spec.js
+++ b/test/domibus/fabriqueMessages.spec.js
@@ -1,0 +1,42 @@
+const FabriqueMessages = require('../../src/domibus/fabriqueMessages');
+const ReponseErreur = require('../../src/domibus/reponseErreur');
+const ReponseErreurAutorisationRequise = require('../../src/domibus/reponseErreurAutorisationRequise');
+const ReponseSucces = require('../../src/domibus/reponseSucces');
+const Requete = require('../../src/domibus/requete');
+const Entete = require('../../src/ebms/entete');
+
+describe('La fabrique de messages reçus', () => {
+  it('sait créer une réponse en erreur avec autorisation requise', () => {
+    const xmlParse = {
+      QueryResponse: {
+        '@_status': 'urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Failure',
+        Exception: { '@_type': 'rs:AuthorizationExceptionType' },
+      },
+    };
+
+    const message = FabriqueMessages.nouveauMessage(Entete.REPONSE_ERREUR, xmlParse);
+    expect(message).toBeInstanceOf(ReponseErreurAutorisationRequise);
+  });
+
+  it('sait créer une réponse en erreur avec objet introuvable', () => {
+    const xmlParse = {
+      QueryResponse: {
+        '@_status': 'urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Failure',
+        Exception: { '@_type': 'rs:ObjectNotFoundExceptionType' },
+      },
+    };
+
+    const message = FabriqueMessages.nouveauMessage(Entete.REPONSE_ERREUR, xmlParse);
+    expect(message).toBeInstanceOf(ReponseErreur);
+  });
+
+  it('sait créer une requête', () => {
+    const message = FabriqueMessages.nouveauMessage(Entete.EXECUTION_REQUETE);
+    expect(message).toBeInstanceOf(Requete);
+  });
+
+  it('sait créer une réponse en succès', () => {
+    const message = FabriqueMessages.nouveauMessage(Entete.EXECUTION_REPONSE);
+    expect(message).toBeInstanceOf(ReponseSucces);
+  });
+});

--- a/test/domibus/reponseErreur.spec.js
+++ b/test/domibus/reponseErreur.spec.js
@@ -1,0 +1,18 @@
+const ReponseErreur = require('../../src/domibus/reponseErreur');
+const { ErreurReponseRequete } = require('../../src/erreurs');
+
+describe("Une réponse Domibus reçue en erreur (différente d'autorisation requise)", () => {
+  it('lance une erreur comme suite de conversation', (suite) => {
+    const xmlParse = { QueryResponse: { Exception: { '@_message': 'oups' } } };
+    const reponse = new ReponseErreur(xmlParse);
+
+    try {
+      reponse.suiteConversation();
+      suite('La suite de conversation aurait dû lever une ErreurReponseRequete');
+    } catch (e) {
+      expect(e).toBeInstanceOf(ErreurReponseRequete);
+      expect(e.message).toEqual('oups');
+      suite();
+    }
+  });
+});

--- a/test/domibus/reponseErreurAutorisationRequise.spec.js
+++ b/test/domibus/reponseErreurAutorisationRequise.spec.js
@@ -1,0 +1,21 @@
+const ReponseErreurAutorisationRequise = require('../../src/domibus/reponseErreurAutorisationRequise');
+
+describe('Une réponse Domibus reçue avec erreur autorisation requise', () => {
+  it("renvoie comme suite de conversation l'URL de redirection", () => {
+    const xmlParse = {
+      QueryResponse: {
+        Exception: {
+          Slot: [
+            {
+              '@_name': 'PreviewLocation',
+              SlotValue: { Value: 'https://example.com' },
+            },
+          ],
+        },
+      },
+    };
+
+    const reponse = new ReponseErreurAutorisationRequise(xmlParse);
+    expect(reponse.suiteConversation()).toEqual('https://example.com');
+  });
+});

--- a/test/domibus/reponseRecuperationMessage.spec.js
+++ b/test/domibus/reponseRecuperationMessage.spec.js
@@ -1,4 +1,5 @@
 const ConstructeurEnveloppeSOAPException = require('../constructeurs/constructeurEnveloppeSOAPException');
+const ReponseErreurAutorisationRequise = require('../../src/domibus/reponseErreurAutorisationRequise');
 const ReponseRecuperationMessage = require('../../src/domibus/reponseRecuperationMessage');
 const { ErreurReponseRequete } = require('../../src/erreurs');
 
@@ -9,7 +10,8 @@ describe('La réponse à une requête Domibus de récupération de message', () 
       .construis();
     const reponse = new ReponseRecuperationMessage(enveloppeSOAP);
 
-    expect(reponse.urlRedirection()).toEqual('https://example.com/preview/12345678-1234-1234-1234-1234567890ab');
+    expect(reponse.corpsMessage).toBeInstanceOf(ReponseErreurAutorisationRequise);
+    expect(reponse.suiteConversation()).toEqual('https://example.com/preview/12345678-1234-1234-1234-1234567890ab');
   });
 
   it("connaît le type d'action liée au message", () => {
@@ -69,7 +71,7 @@ describe('La réponse à une requête Domibus de récupération de message', () 
       const reponse = new ReponseRecuperationMessage(enveloppeSOAP);
 
       try {
-        reponse.urlRedirection();
+        reponse.suiteConversation();
         suite('Une `ErreurReponseRequete` aurait dû être levée.');
       } catch (e) {
         expect(e).toBeInstanceOf(ErreurReponseRequete);


### PR DESCRIPTION
… pour tirer parti du polymorphisme et ne pas rechercher d'URL de redirection si on n'est pas dans le cas d'une
`ReponseErreurAutorisationRequise`.