### PR TITLE
Sépare les variables d'environnement

### DIFF
--- a/.env.oots.template
+++ b/.env.oots.template
@@ -1,0 +1,5 @@
+DELAI_MAX_ATTENTE_DOMIBUS= # délai maximum d'attente d'une réponse Domibus à une requête envoyée (en millisecondes)
+EXPEDITEUR_DOMIBUS= # nom expéditeur Domibus
+SUFFIXE_IDENTIFIANTS_DOMIBUS= # suffixe à ajouter dans les trames EBMS, ex. oots.eu
+URL_BASE_DOMIBUS= # URL instance Domibus, ex. https://domibus.gouv.fr
+URL_OOTS_FRANCE= # URL Serveur OOTS-France, ex. https://oots.gouv.fr

--- a/.env.template
+++ b/.env.template
@@ -1,6 +1,1 @@
-DELAI_MAX_ATTENTE_DOMIBUS= # délai maximum d'attente d'une réponse Domibus à une requête envoyée (en millisecondes)
-EXPEDITEUR_DOMIBUS= # nom expéditeur Domibus
 PORT_OOTS_FRANCE= # port sur lequel le serveur écoute
-SUFFIXE_IDENTIFIANTS_DOMIBUS= # suffixe à ajouter dans les trames EBMS, ex. oots.eu
-URL_BASE_DOMIBUS= # URL instance Domibus, ex. https://domibus.gouv.fr
-URL_OOTS_FRANCE= # URL Serveur OOTS-France, ex. https://oots.gouv.fr

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
+.env.oots
 node_modules/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ x-app:
   build:
     context: .
   env_file:
-    - .env
+    - ./.env.oots
   volumes:
     - .:/usr/src/app
     - node_modules:/usr/src/app/node_modules/


### PR DESCRIPTION
Le fichier `.env` sert en premier lieu à injecter des variables dans `docker-compose.yml`, et n'a pas besoin d'être spécifié comme valeur de l'attribut `env-file`.

Les fichiers indiqués comme valeurs de l'attribut `env-file` servent à injecter des variables _dans le conteneur_ – et servent en premier lieu à renseigner les variables d'environnement présentes dans le code.

En vue d'une prochaine intégration d'un conteneur Domibus, ce commit entame la séparation des variables utilisées par `docker-compose.yml` des autres variables.