### PR TITLE
N'affiche pas les logs Domibus

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,9 @@ services:
       - domibus.metrics.monitor.memory=false
       - domibus.metrics.monitor.gc=false
       - domibus.metrics.monitor.cached.threads=false
+    logging:
+      driver:
+        none
     ports:
       - "${PORT_DOMIBUS}:8080"
     volumes:


### PR DESCRIPTION
Cf. [documentation docker](https://docs.docker.com/config/containers/logging/configure/) pour plus d'information sur la configuration de la journalisation pour chaque conteneur.