### PR TITLE
[CORRECTION] stabilise les tests unitaires asynchrones d'ecouteurDomibus

### DIFF
--- a/test/ecouteurDomibus.spec.js
+++ b/test/ecouteurDomibus.spec.js
@@ -1,75 +1,57 @@
 const EcouteurDomibus = require('../src/ecouteurDomibus');
 
 describe("L'écouteur Domibus", () => {
+  jest.useFakeTimers();
   const adaptateurDomibus = {};
 
   beforeEach(() => {
-    adaptateurDomibus.traiteMessageSuivant = () => {};
+    adaptateurDomibus.traiteMessageSuivant = () => {
+    };
   });
 
-  it('peut être démarré et arrêté', (suite) => {
-    let nbAppelsTraiteMessageSuivant = 0;
-    adaptateurDomibus.traiteMessageSuivant = () => {
-      nbAppelsTraiteMessageSuivant += 1;
-    };
+  it('peut être démarré et arrêté', () => {
+    adaptateurDomibus.traiteMessageSuivant = jest.fn();
 
     const ecouteur = new EcouteurDomibus({ adaptateurDomibus, intervalleEcoute: 20 });
     ecouteur.ecoute();
 
-    setTimeout(() => {
-      ecouteur.arreteEcoute();
-      try {
-        expect(nbAppelsTraiteMessageSuivant).toEqual(2);
-        suite();
-      } catch (e) {
-        suite(e);
-      }
-    }, 50);
+    expect(adaptateurDomibus.traiteMessageSuivant).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(50);
+
+    expect(adaptateurDomibus.traiteMessageSuivant).toHaveBeenCalled();
+    expect(adaptateurDomibus.traiteMessageSuivant).toHaveBeenCalledTimes(2);
+
+    ecouteur.arreteEcoute();
+
+    jest.advanceTimersByTime(50);
+
+    expect(adaptateurDomibus.traiteMessageSuivant).toHaveBeenCalledTimes(2);
   });
 
-  it("n'est démarré qu'une seule fois à la fois", (suite) => {
-    let nbAppelsTraiteMessageSuivant = 0;
-    adaptateurDomibus.traiteMessageSuivant = () => {
-      nbAppelsTraiteMessageSuivant += 1;
-    };
-
-    const ecouteur = new EcouteurDomibus({ adaptateurDomibus, intervalleEcoute: 30 });
-    ecouteur.ecoute();
-    ecouteur.ecoute();
-
-    setTimeout(() => {
-      ecouteur.arreteEcoute();
-      try {
-        expect(nbAppelsTraiteMessageSuivant).toEqual(2);
-        suite();
-      } catch (e) {
-        suite(e);
-      }
-    }, 70);
-  });
-
-  it("peut être redémarré s'il a été arrêté", (suite) => {
-    let nbAppelsTraiteMessageSuivant = 0;
-    adaptateurDomibus.traiteMessageSuivant = () => {
-      nbAppelsTraiteMessageSuivant += 1;
-    };
+  it("n'est démarré qu'une seule fois à la fois", () => {
+    adaptateurDomibus.traiteMessageSuivant = jest.fn();
 
     const ecouteur = new EcouteurDomibus({ adaptateurDomibus, intervalleEcoute: 20 });
     ecouteur.ecoute();
+    ecouteur.ecoute();
 
-    setTimeout(() => {
-      ecouteur.arreteEcoute();
-      ecouteur.ecoute();
-    }, 30);
+    jest.advanceTimersByTime(30);
 
-    setTimeout(() => {
-      ecouteur.arreteEcoute();
-      try {
-        expect(nbAppelsTraiteMessageSuivant).toEqual(2);
-        suite();
-      } catch (e) {
-        suite(e);
-      }
-    }, 60);
+    expect(adaptateurDomibus.traiteMessageSuivant).toHaveBeenCalledTimes(1);
+  });
+
+  it("peut être redémarré s'il a été arrêté", () => {
+    adaptateurDomibus.traiteMessageSuivant = jest.fn();
+
+    const ecouteur = new EcouteurDomibus({ adaptateurDomibus, intervalleEcoute: 20 });
+    ecouteur.ecoute();
+    jest.advanceTimersByTime(30);
+    ecouteur.arreteEcoute();
+    ecouteur.ecoute();
+
+    jest.advanceTimersByTime(30);
+
+    expect(adaptateurDomibus.traiteMessageSuivant).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
Jest ne fonctionnait pas bien avec setInterval et les tests échouaient de manière aléatoire.
Ce commit résout le problème.

cf. https://jestjs.io/docs/timer-mocks