### PR TITLE
Pose un interrupteur sur l API /requete/diplomeSecondDegre

### DIFF
--- a/.env.oots.template
+++ b/.env.oots.template
@@ -1,3 +1,4 @@
+AVEC_REQUETE_DIPLOME_SECOND_DEGRE= #active l'API /requete/diplomeSecondDegre avec valeur true
 DELAI_MAX_ATTENTE_DOMIBUS= # délai maximum d'attente d'une réponse Domibus à une requête envoyée (en millisecondes)
 EXPEDITEUR_DOMIBUS= # nom expéditeur Domibus
 SUFFIXE_IDENTIFIANTS_DOMIBUS= # suffixe à ajouter dans les trames EBMS, ex. oots.eu

--- a/server.js
+++ b/server.js
@@ -1,14 +1,16 @@
+const EcouteurDomibus = require('./src/ecouteurDomibus');
 const OOTS_FRANCE = require('./src/ootsFrance');
 const AdaptateurDomibus = require('./src/adaptateurs/adaptateurDomibus');
+const adaptateurEnvironnement = require('./src/adaptateurs/adaptateurEnvironnement');
 const adaptateurUUID = require('./src/adaptateurs/adaptateurUUID');
 const horodateur = require('./src/adaptateurs/horodateur');
-const EcouteurDomibus = require('./src/ecouteurDomibus');
 
 const adaptateurDomibus = AdaptateurDomibus({ adaptateurUUID, horodateur });
 const ecouteurDomibus = new EcouteurDomibus({ adaptateurDomibus, intervalleEcoute: 1000 });
 
 const serveur = OOTS_FRANCE.creeServeur({
   adaptateurDomibus,
+  adaptateurEnvironnement,
   adaptateurUUID,
   ecouteurDomibus,
   horodateur,

--- a/src/adaptateurs/adaptateurEnvironnement.js
+++ b/src/adaptateurs/adaptateurEnvironnement.js
@@ -1,0 +1,3 @@
+const avecRequeteDiplomeSecondDegre = () => process.env.AVEC_REQUETE_DIPLOME_SECOND_DEGRE === 'true';
+
+module.exports = { avecRequeteDiplomeSecondDegre };

--- a/src/ootsFrance.js
+++ b/src/ootsFrance.js
@@ -10,6 +10,7 @@ const JustificatifEducation = require('./vues/justificatifEducation');
 const creeServeur = (config) => {
   const {
     adaptateurDomibus,
+    adaptateurEnvironnement,
     adaptateurUUID,
     ecouteurDomibus,
     horodateur,
@@ -84,7 +85,13 @@ const creeServeur = (config) => {
     reponse.send(reponseErreur.enXML());
   });
 
-  app.get('/requete/diplomeSecondDegre', (...args) => diplomeSecondDegre(adaptateurDomibus, adaptateurUUID, ...args));
+  app.get('/requete/diplomeSecondDegre', (requete, reponse) => {
+    if (adaptateurEnvironnement.avecRequeteDiplomeSecondDegre()) {
+      diplomeSecondDegre(adaptateurDomibus, adaptateurUUID, requete, reponse);
+    } else {
+      reponse.status(501).send('Not Implemented Yet!');
+    }
+  });
 
   app.get('/idMessageTest', (_requete, reponse) => adaptateurDomibus
     .envoieMessageTest('oots_test_platform')


### PR DESCRIPTION
pilotable par variable d'environnement

En vue d'une MEP, tant qu'il n'y a pas d'authentification sur le serveur on ferme les APIs de requête.