### PR TITLE
Corrige statut HTTP pour erreur « Not Implemented »

### DIFF
--- a/src/ootsFrance.js
+++ b/src/ootsFrance.js
@@ -98,7 +98,7 @@ const creeServeur = (config) => {
     .then(({ data }) => reponse.send(data)));
 
   app.get('/', (_requete, reponse) => {
-    reponse.status(504).send('Not Implemented Yet!');
+    reponse.status(501).send('Not Implemented Yet!');
   });
 
   const ecoute = (...args) => { serveur = app.listen(...args); };

--- a/test/ootsFrance.spec.js
+++ b/test/ootsFrance.spec.js
@@ -181,11 +181,11 @@ describe('Le serveur OOTS France', () => {
   });
 
   describe('sur GET /', () => {
-    it('sert une erreur HTTP 504 (not implemented)', () => {
+    it('sert une erreur HTTP 501 (not implemented)', () => {
       expect.assertions(1);
 
       return axios.get('http://localhost:1234/')
-        .catch((erreur) => expect(erreur.response.status).toEqual(504));
+        .catch((erreur) => expect(erreur.response.status).toEqual(501));
     });
   });
 });


### PR DESCRIPTION
 Le code pour « Not Implemented » est 501, et non 504.
(cf. https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/501)