### PR TITLE
Utilise des ports aléatoires pour tester le comportement du serveur

### DIFF
--- a/src/ootsFrance.js
+++ b/src/ootsFrance.js
@@ -101,13 +101,16 @@ const creeServeur = (config) => {
     reponse.status(501).send('Not Implemented Yet!');
   });
 
+  const arreteEcoute = (suite) => serveur.close(suite);
+
   const ecoute = (...args) => { serveur = app.listen(...args); };
 
-  const arreteEcoute = (suite) => serveur.close(suite);
+  const port = () => serveur.address().port;
 
   return {
     arreteEcoute,
     ecoute,
+    port,
   };
 };
 


### PR DESCRIPTION
… Cela afin d'éviter les erreurs aléatoires et dépendantes de l'OS quand on tente de réutiliser dans le test suivant un socket qui a été fermé mais qui n'est pas encore disponible à la réouverture.