### PR TITLE
[CORRECTION] Paramétrise type identifiant point access Domibus

### DIFF
--- a/.env.oots.template
+++ b/.env.oots.template
@@ -1,7 +1,8 @@
 AVEC_REQUETE_PIECE_JUSTIFICATIVE= #active l'API /requete/pieceJustificative avec valeur true
 DELAI_MAX_ATTENTE_DOMIBUS= # délai maximum d'attente d'une réponse Domibus à une requête envoyée (en millisecondes)
-EXPEDITEUR_DOMIBUS= # nom expéditeur Domibus
+IDENTIFIANT_EXPEDITEUR_DOMIBUS= # identifiant expéditeur Domibus
 SUFFIXE_IDENTIFIANTS_DOMIBUS= # suffixe à ajouter dans les trames EBMS, ex. oots.eu
+TYPE_IDENTIFIANT_EXPEDITEUR_DOMIBUS= # type d'identifiant expéditeur Domibus
 URL_BASE_DOMIBUS= # URL instance Domibus, ex. https://domibus.gouv.fr
 URL_OOTS_FRANCE= # URL Serveur OOTS-France, ex. https://oots.gouv.fr
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Le serveur devrait être accessible depuis un navigateur à l'URL
 
 Il est alors possible de tester l'envoi d'un message de test en requêtant l'URL
 suivante depuis un navigateur :
-`http://localhost:[PORT_OOTS_FRANCE]/requete/pieceJustificative?destinataire=blue_gw`.
+`http://localhost:[PORT_OOTS_FRANCE]/requete/pieceJustificative?nomDestinataire=blue_gw`.
 
 
 ## Exécution de la suite de tests automatisés

--- a/server.js
+++ b/server.js
@@ -4,14 +4,17 @@ const AdaptateurDomibus = require('./src/adaptateurs/adaptateurDomibus');
 const adaptateurEnvironnement = require('./src/adaptateurs/adaptateurEnvironnement');
 const adaptateurUUID = require('./src/adaptateurs/adaptateurUUID');
 const horodateur = require('./src/adaptateurs/horodateur');
+const DepotPointsAcces = require('./src/depots/depotPointsAcces');
 
 const adaptateurDomibus = AdaptateurDomibus({ adaptateurUUID, horodateur });
+const depotPointsAcces = new DepotPointsAcces(adaptateurDomibus);
 const ecouteurDomibus = new EcouteurDomibus({ adaptateurDomibus, intervalleEcoute: 1000 });
 
 const serveur = OOTS_FRANCE.creeServeur({
   adaptateurDomibus,
   adaptateurEnvironnement,
   adaptateurUUID,
+  depotPointsAcces,
   ecouteurDomibus,
   horodateur,
 });

--- a/src/adaptateurs/adaptateurDomibus.js
+++ b/src/adaptateurs/adaptateurDomibus.js
@@ -4,7 +4,6 @@ const EventEmitter = require('node:events');
 const {
   ErreurAbsenceReponseDestinataire,
   ErreurAucunMessageDomibusRecu,
-  ErreurDestinataireInexistant,
 } = require('../erreurs');
 const { requeteListeMessagesEnAttente, requeteRecuperationMessage } = require('../domibus/requetes');
 const ReponseEnvoiMessage = require('../domibus/reponseEnvoiMessage');
@@ -178,18 +177,16 @@ const AdaptateurDomibus = (config = {}) => {
       }, process.env.DELAI_MAX_ATTENTE_DOMIBUS);
     },
   );
-  const verifieDestinataireExiste = (destinataire) => envoieRequeteREST('ext/party', { partyId: destinataire })
-    .then((destinataires) => ((destinataires.length === 0)
-      ? Promise.reject(new ErreurDestinataireInexistant(`Le destinataire n'existe pas : ${destinataire}`))
-      : Promise.resolve()));
+
+  const trouvePointAcces = (nomPointAcces) => envoieRequeteREST('ext/party', { name: nomPointAcces });
 
   return {
     envoieMessageRequete,
     envoieMessageTest,
     pieceJustificativeDepuisReponse,
     traiteMessageSuivant,
+    trouvePointAcces,
     urlRedirectionDepuisReponse,
-    verifieDestinataireExiste,
   };
 };
 

--- a/src/adaptateurs/adaptateurDomibus.js
+++ b/src/adaptateurs/adaptateurDomibus.js
@@ -68,9 +68,7 @@ const AdaptateurDomibus = (config = {}) => {
   };
 
   const envoieRequeteREST = (chemin, parametres) => {
-    const jetonEncode = btoa(
-      `${process.env.LOGIN_API_REST}:${process.env.MOT_DE_PASSE_API_REST}`,
-    );
+    const jetonEncode = btoa(`${process.env.LOGIN_API_REST}:${process.env.MOT_DE_PASSE_API_REST}`);
 
     return axios({
       method: 'get',

--- a/src/api/pieceJustificative.js
+++ b/src/api/pieceJustificative.js
@@ -41,7 +41,7 @@ const pieceJustificative = (
     })
     .catch((e) => {
       if (e instanceof ErreurDestinataireInexistant) {
-        reponse.status(422).send(e.message);
+        reponse.status(422).json({ erreur: e.message });
       } else if (e instanceof AggregateError) {
         let codeStatus = 500;
         if (e.errors.every(estErreurAbsenceReponse)) {
@@ -49,7 +49,7 @@ const pieceJustificative = (
         } else if (e.errors.every(estErreurMetier)) {
           codeStatus = 502;
         }
-        reponse.status(codeStatus).send(e.errors.map((erreur) => erreur.message).join(' ; '));
+        reponse.status(codeStatus).json({ erreur: e.errors.map((erreur) => erreur.message).join(' ; ') });
       } else throw e;
     });
 };

--- a/src/api/pieceJustificative.js
+++ b/src/api/pieceJustificative.js
@@ -12,13 +12,16 @@ const estErreurAbsenceReponse = (e) => e instanceof ErreurAbsenceReponseDestinat
 const estErreurReponseRequete = (e) => e instanceof ErreurReponseRequete;
 const estErreurMetier = (e) => estErreurAbsenceReponse(e) || estErreurReponseRequete(e);
 
-const pieceJustificative = (adaptateurDomibus, adaptateurUUID, requete, reponse) => {
+const pieceJustificative = (
+  { adaptateurDomibus, adaptateurUUID, depotPointsAcces },
+  requete,
+  reponse,
+) => {
   const idConversation = adaptateurUUID.genereUUID();
-  const { codeDemarche, destinataire, previsualisationRequise } = requete.query;
+  const { codeDemarche, nomDestinataire, previsualisationRequise } = requete.query;
 
-  return adaptateurDomibus
-    .verifieDestinataireExiste(destinataire)
-    .then(() => adaptateurDomibus.envoieMessageRequete({
+  return depotPointsAcces.trouvePointAcces(nomDestinataire)
+    .then((destinataire) => adaptateurDomibus.envoieMessageRequete({
       codeDemarche,
       destinataire,
       idConversation,

--- a/src/depots/depotPointsAcces.js
+++ b/src/depots/depotPointsAcces.js
@@ -1,0 +1,24 @@
+const { ErreurDestinataireInexistant } = require('../erreurs');
+
+class DepotPointsAcces {
+  constructor(adaptateurDomibus) {
+    this.adaptateurDomibus = adaptateurDomibus;
+  }
+
+  trouvePointAcces(nom) {
+    return this.adaptateurDomibus.trouvePointAcces(nom)
+      .then((pointsAcces) => {
+        if (pointsAcces.length === 0) {
+          throw new ErreurDestinataireInexistant(`Point d'accès inexistant : ${nom}`);
+        }
+
+        const infosIdentifiant = pointsAcces[0].identifiers[0];
+        return {
+          typeIdentifiant: infosIdentifiant.partyIdType.value,
+          id: infosIdentifiant.partyId,
+        };
+      });
+  }
+}
+
+module.exports = DepotPointsAcces;

--- a/src/domibus/enteteMessageRecu.js
+++ b/src/domibus/enteteMessageRecu.js
@@ -9,7 +9,12 @@ class EnteteMessageRecu {
   }
 
   expediteur() {
-    return this.enteteMessageUtilisateur.PartyInfo.From.PartyId['#text'];
+    const infosExpediteur = this.enteteMessageUtilisateur.PartyInfo.From.PartyId;
+
+    return {
+      typeIdentifiant: infosExpediteur['@_type'],
+      id: infosExpediteur['#text'],
+    };
   }
 
   idConversation() {

--- a/src/ebms/entete.js
+++ b/src/ebms/entete.js
@@ -6,7 +6,8 @@ const ACTIONS = {
 
 class Entete {
   constructor(config = {}, donnees = {}) {
-    this.expediteur = process.env.EXPEDITEUR_DOMIBUS;
+    this.identifiantExpediteur = process.env.IDENTIFIANT_EXPEDITEUR_DOMIBUS;
+    this.typeIdentifiantExpediteur = process.env.TYPE_IDENTIFIANT_EXPEDITEUR_DOMIBUS;
 
     this.horodateur = config.horodateur;
     this.destinataire = donnees.destinataire;
@@ -40,8 +41,8 @@ class Entete {
     </eb:MessageInfo>
     <eb:PartyInfo>
       <eb:From>
-        <eb:PartyId type="urn:oasis:names:tc:ebcore:partyid-type:unregistered:oots-simulator">
-          ${this.expediteur}
+        <eb:PartyId type="${this.typeIdentifiantExpediteur}">
+          ${this.identifiantExpediteur}
         </eb:PartyId>
         <eb:Role>http://sdg.europa.eu/edelivery/gateway</eb:Role>
       </eb:From>

--- a/src/ebms/entete.js
+++ b/src/ebms/entete.js
@@ -10,7 +10,8 @@ class Entete {
     this.typeIdentifiantExpediteur = process.env.TYPE_IDENTIFIANT_EXPEDITEUR_DOMIBUS;
 
     this.horodateur = config.horodateur;
-    this.destinataire = donnees.destinataire;
+    this.identifiantDestinataire = donnees.destinataire?.id;
+    this.typeIdentifiantDestinataire = donnees.destinataire?.typeIdentifiant;
     this.idConversation = donnees.idConversation;
     this.idPayload = donnees.idPayload;
 
@@ -47,8 +48,8 @@ class Entete {
         <eb:Role>http://sdg.europa.eu/edelivery/gateway</eb:Role>
       </eb:From>
       <eb:To>
-        <eb:PartyId type="urn:oasis:names:tc:ebcore:partyid-type:unregistered:oots-simulator">
-          ${this.destinataire}
+        <eb:PartyId type="${this.typeIdentifiantDestinataire}">
+          ${this.identifiantDestinataire}
         </eb:PartyId>
         <eb:Role>http://sdg.europa.eu/edelivery/gateway</eb:Role>
       </eb:To>

--- a/src/ootsFrance.js
+++ b/src/ootsFrance.js
@@ -12,6 +12,7 @@ const creeServeur = (config) => {
     adaptateurDomibus,
     adaptateurEnvironnement,
     adaptateurUUID,
+    depotPointsAcces,
     ecouteurDomibus,
     horodateur,
   } = config;
@@ -87,7 +88,7 @@ const creeServeur = (config) => {
 
   app.get('/requete/pieceJustificative', (requete, reponse) => {
     if (adaptateurEnvironnement.avecRequetePieceJustificative()) {
-      pieceJustificative(adaptateurDomibus, adaptateurUUID, requete, reponse);
+      pieceJustificative({ adaptateurDomibus, adaptateurUUID, depotPointsAcces }, requete, reponse);
     } else {
       reponse.status(501).send('Not Implemented Yet!');
     }

--- a/test/api/pieceJustificative.spec.js
+++ b/test/api/pieceJustificative.spec.js
@@ -21,9 +21,10 @@ describe('Le requêteur de pièce justificative', () => {
     depotPointsAcces.trouvePointAcces = () => Promise.resolve({});
 
     requete.query = {};
+    reponse.json = () => Promise.resolve();
+    reponse.redirect = () => Promise.resolve();
     reponse.send = () => Promise.resolve();
     reponse.status = () => reponse;
-    reponse.redirect = () => Promise.resolve();
   });
 
   it('envoie un message AS4 au bon destinataire', () => {
@@ -123,8 +124,8 @@ describe('Le requêteur de pièce justificative', () => {
       return reponse;
     };
 
-    reponse.send = (contenu) => {
-      expect(contenu).toEqual('object not found ; aucun justificatif reçu');
+    reponse.json = (contenu) => {
+      expect(contenu).toEqual({ erreur: 'object not found ; aucun justificatif reçu' });
     };
 
     return pieceJustificative(config, requete, reponse);
@@ -138,8 +139,8 @@ describe('Le requêteur de pièce justificative', () => {
       expect(codeStatus).toEqual(422);
       return reponse;
     };
-    reponse.send = (contenu) => {
-      expect(contenu).toEqual('Oups');
+    reponse.json = (contenu) => {
+      expect(contenu).toEqual({ erreur: 'Oups' });
     };
 
     return pieceJustificative(config, requete, reponse);

--- a/test/constructeurs/constructeurEnveloppeSOAPException.js
+++ b/test/constructeurs/constructeurEnveloppeSOAPException.js
@@ -31,7 +31,8 @@ class ConstructeurEnveloppeSOAPException {
   }
 
   avecExpediteur(expediteur) {
-    this.expediteur = expediteur;
+    this.identifiantExpediteur = expediteur.id;
+    this.typeIdentifiantExpediteur = expediteur.typeIdentifiant;
     return this;
   }
 
@@ -94,7 +95,7 @@ class ConstructeurEnveloppeSOAPException {
         </ns5:MessageInfo>
         <ns5:PartyInfo>
             <ns5:From>
-                <ns5:PartyId type="urn:cef.eu:names:identifier:EAS:0204">${this.expediteur}</ns5:PartyId>
+                <ns5:PartyId type="${this.typeIdentifiantExpediteur}">${this.identifiantExpediteur}</ns5:PartyId>
                 <ns5:Role>http://sdg.europa.eu/edelivery/gateway</ns5:Role>
             </ns5:From>
             <ns5:To>

--- a/test/depots/depotPointsAcces.spec.js
+++ b/test/depots/depotPointsAcces.spec.js
@@ -1,0 +1,51 @@
+const DepotPointsAcces = require('../../src/depots/depotPointsAcces');
+const { ErreurDestinataireInexistant } = require('../../src/erreurs');
+
+describe("Le dépôt des points d'accès", () => {
+  const adaptateurDomibus = {};
+
+  beforeEach(() => {
+    adaptateurDomibus.trouvePointAcces = () => Promise.resolve();
+  });
+
+  it("trouve les informations du point d'accès par son nom", () => {
+    adaptateurDomibus.trouvePointAcces = (nom) => {
+      const reponse = [{
+        name: 'unNom',
+        identifiers: [{
+          partyId: 'unId',
+          partyIdType: {
+            name: 'partyTypeUrn',
+            value: 'urn:oasis:names:tc:ebcore:partyid-type:unregistered:oots-simulator',
+          },
+        }],
+        // … et d'autres valeurs inutilisées
+      }];
+
+      try {
+        expect(nom).toBe('unNom');
+        return Promise.resolve(reponse);
+      } catch (e) {
+        return Promise.reject(e);
+      }
+    };
+
+    const depot = new DepotPointsAcces(adaptateurDomibus);
+    return expect(depot.trouvePointAcces('unNom')).resolves.toEqual({
+      typeIdentifiant: 'urn:oasis:names:tc:ebcore:partyid-type:unregistered:oots-simulator',
+      id: 'unId',
+    });
+  });
+
+  it("retourne une `ErreurDestinataireInexistant` si le nom du point d'accès est inconnu", () => {
+    expect.assertions(2);
+    adaptateurDomibus.trouvePointAcces = () => Promise.resolve([]);
+
+    const depot = new DepotPointsAcces(adaptateurDomibus);
+    return depot.trouvePointAcces('unNom')
+      .catch((e) => {
+        expect(e).toBeInstanceOf(ErreurDestinataireInexistant);
+        expect(e.message).toBe("Point d'accès inexistant : unNom");
+      });
+  });
+});

--- a/test/domibus/reponseRecuperationMessage.spec.js
+++ b/test/domibus/reponseRecuperationMessage.spec.js
@@ -36,11 +36,11 @@ describe('La réponse à une requête Domibus de récupération de message', () 
 
   it("connaît l'expéditeur", () => {
     const enveloppeSOAP = ConstructeurEnveloppeSOAPException.erreurAutorisationRequise()
-      .avecExpediteur('AP_SI_01')
+      .avecExpediteur({ typeIdentifiant: 'unType', id: 'unIdentifiant' })
       .construis();
     const reponse = new ReponseRecuperationMessage(enveloppeSOAP);
 
-    expect(reponse.expediteur()).toEqual('AP_SI_01');
+    expect(reponse.expediteur()).toEqual({ typeIdentifiant: 'unType', id: 'unIdentifiant' });
   });
 
   it('connaît son identifiant de message', () => {

--- a/test/ebms/enteteRequete.spec.js
+++ b/test/ebms/enteteRequete.spec.js
@@ -50,6 +50,33 @@ describe("l'entête EBMS de requête", () => {
     });
   });
 
+  describe('dans le chemin /Messaging/UserMessage/PartyInfo', () => {
+    let identifiantExpediteur;
+    let typeIdentifiantExpediteur;
+
+    beforeEach(() => {
+      identifiantExpediteur = process.env.IDENTIFIANT_EXPEDITEUR_DOMIBUS;
+      typeIdentifiantExpediteur = process.env.TYPE_IDENTIFIANT_EXPEDITEUR_DOMIBUS;
+    });
+
+    afterEach(() => {
+      process.env.IDENTIFIANT_EXPEDITEUR_DOMIBUS = identifiantExpediteur;
+      process.env.TYPE_IDENTIFIANT_EXPEDITEUR_DOMIBUS = typeIdentifiantExpediteur;
+    });
+
+    it("renseigne l'expéditeur (C2)", () => {
+      process.env.IDENTIFIANT_EXPEDITEUR_DOMIBUS = 'unIdentifiant';
+      process.env.TYPE_IDENTIFIANT_EXPEDITEUR_DOMIBUS = 'unType';
+
+      const enteteEBMS = new EnteteRequete({ adaptateurUUID, horodateur });
+      const xml = parseXML(enteteEBMS.enXML());
+      const expediteur = xml.Messaging.UserMessage.PartyInfo.From.PartyId;
+
+      expect(expediteur['@_type']).toBe('unType');
+      expect(expediteur['#text']).toBe('unIdentifiant');
+    });
+  });
+
   describe('dans le chemin /Messaging/UserMessage/MessageProperties', () => {
     it("renseigne l'expéditeur (C1)", () => {
       const enteteEBMS = new EnteteRequete({ adaptateurUUID, horodateur });

--- a/test/ebms/enteteRequete.spec.js
+++ b/test/ebms/enteteRequete.spec.js
@@ -28,7 +28,7 @@ describe("l'entête EBMS de requête", () => {
     expect(userMessageInfos.PayloadInfo).toBeDefined();
   });
 
-  describe('dans le chemin /eb:Messaging/eb:UserMessage/eb:MessageInfo', () => {
+  describe('dans le chemin /Messaging/UserMessage/MessageInfo', () => {
     it('est horodaté', () => {
       horodateur.maintenant = () => '2023-09-01T15:30:00.000Z';
       const enteteEBMS = new EnteteRequete({ adaptateurUUID, horodateur });
@@ -50,7 +50,7 @@ describe("l'entête EBMS de requête", () => {
     });
   });
 
-  describe('dans le chemin /eb:Messaging/eb:UserMessage/eb:MessageProperties', () => {
+  describe('dans le chemin /Messaging/UserMessage/MessageProperties', () => {
     it("renseigne l'expéditeur (C1)", () => {
       const enteteEBMS = new EnteteRequete({ adaptateurUUID, horodateur });
       const xml = parseXML(enteteEBMS.enXML());
@@ -72,7 +72,7 @@ describe("l'entête EBMS de requête", () => {
     });
   });
 
-  describe('dans le chemin /eb:Messaging/eb:UserMessage/eb:PayloadInfo', () => {
+  describe('dans le chemin /Messaging/UserMessage/PayloadInfo', () => {
     it('identifie le payload du message', () => {
       const enteteEBMS = new EnteteRequete(
         { adaptateurUUID, horodateur },

--- a/test/ebms/enteteRequete.spec.js
+++ b/test/ebms/enteteRequete.spec.js
@@ -75,6 +75,18 @@ describe("l'entête EBMS de requête", () => {
       expect(expediteur['@_type']).toBe('unType');
       expect(expediteur['#text']).toBe('unIdentifiant');
     });
+
+    it('renseigne le destinataire (C3)', () => {
+      const enteteEBMS = new EnteteRequete(
+        { adaptateurUUID, horodateur },
+        { destinataire: { typeIdentifiant: 'unType', id: 'unIdentifiant' } },
+      );
+      const xml = parseXML(enteteEBMS.enXML());
+      const destinataire = xml.Messaging.UserMessage.PartyInfo.To.PartyId;
+
+      expect(destinataire['@_type']).toBe('unType');
+      expect(destinataire['#text']).toBe('unIdentifiant');
+    });
   });
 
   describe('dans le chemin /Messaging/UserMessage/MessageProperties', () => {

--- a/test/ootsFrance.spec.js
+++ b/test/ootsFrance.spec.js
@@ -8,6 +8,7 @@ describe('Le serveur OOTS France', () => {
   const adaptateurDomibus = {};
   const adaptateurEnvironnement = {};
   const adaptateurUUID = {};
+  const depotPointsAcces = {};
   const ecouteurDomibus = {};
   const horodateur = {};
 
@@ -17,6 +18,7 @@ describe('Le serveur OOTS France', () => {
   beforeEach((suite) => {
     adaptateurEnvironnement.avecRequetePieceJustificative = () => 'true';
     adaptateurUUID.genereUUID = () => '';
+    depotPointsAcces.trouvePointAcces = () => Promise.resolve({});
     ecouteurDomibus.arreteEcoute = () => {};
     ecouteurDomibus.etat = () => '';
     horodateur.maintenant = () => '';
@@ -25,6 +27,7 @@ describe('Le serveur OOTS France', () => {
       adaptateurDomibus,
       adaptateurEnvironnement,
       adaptateurUUID,
+      depotPointsAcces,
       ecouteurDomibus,
       horodateur,
     });
@@ -109,7 +112,6 @@ describe('Le serveur OOTS France', () => {
   describe('sur GET /requete/pieceJustificative', () => {
     beforeEach(() => {
       adaptateurDomibus.envoieMessageRequete = () => Promise.resolve();
-      adaptateurDomibus.verifieDestinataireExiste = () => Promise.resolve();
       adaptateurDomibus.urlRedirectionDepuisReponse = () => Promise.reject(new ErreurAbsenceReponseDestinataire('aucune URL reçue'));
       adaptateurDomibus.pieceJustificativeDepuisReponse = () => Promise.resolve(Buffer.from(''));
     });

--- a/test/ootsFrance.spec.js
+++ b/test/ootsFrance.spec.js
@@ -124,7 +124,7 @@ describe('Le serveur OOTS France', () => {
         return axios.get(`http://localhost:${port}/requete/pieceJustificative?destinataire=DESTINATAIRE_SILENCIEUX`)
           .catch(({ response }) => {
             expect(response.status).toEqual(504);
-            expect(response.data).toEqual('aucune URL reçue ; aucune pièce reçue');
+            expect(response.data).toEqual({ erreur: 'aucune URL reçue ; aucune pièce reçue' });
           });
       });
     });


### PR DESCRIPTION
Jusqu'ici, on faisait l'hypothèse que le type d'identifiant des divers points d'accès Domibus était `urn:oasis:names:tc:ebcore:partyid-type:unregistered:oots-simulator`, ce qui n'est plus le cas dans les environnements de préproduction et de production. Cette PR corrige le problème.