### PR TITLE
[CORRECTION] Retourne erreur si `nomDestinataire` absent dans URL

### DIFF
--- a/src/depots/depotPointsAcces.js
+++ b/src/depots/depotPointsAcces.js
@@ -6,6 +6,10 @@ class DepotPointsAcces {
   }
 
   trouvePointAcces(nom) {
+    if (typeof nom === 'undefined' || nom === '') {
+      return Promise.reject(new ErreurDestinataireInexistant('Destinataire non renseigné'));
+    }
+
     return this.adaptateurDomibus.trouvePointAcces(nom)
       .then((pointsAcces) => {
         if (pointsAcces.length === 0) {

--- a/test/depots/depotPointsAcces.spec.js
+++ b/test/depots/depotPointsAcces.spec.js
@@ -1,5 +1,43 @@
+const adaptateurUUID = require('../../src/adaptateurs/adaptateurUUID');
 const DepotPointsAcces = require('../../src/depots/depotPointsAcces');
 const { ErreurDestinataireInexistant } = require('../../src/erreurs');
+
+class ConstructeurPointAcces {
+  constructor() {
+    this.nom = adaptateurUUID.genereUUID();
+    this.id = this.nom;
+    this.typeIdentifiant = 'urn:oasis:names:tc:ebcore:partyid-type:unregistered:oots-simulator';
+  }
+
+  avecId(id) {
+    this.id = id;
+    return this;
+  }
+
+  avecNom(nom) {
+    this.nom = nom;
+    return this;
+  }
+
+  avecTypeIdentifiant(type) {
+    this.typeIdentifiant = type;
+    return this;
+  }
+
+  construis() {
+    return {
+      name: this.nom,
+      identifiers: [{
+        partyId: this.id,
+        partyIdType: {
+          name: 'partyTypeUrn',
+          value: this.typeIdentifiant,
+        },
+      }],
+      // … et d'autres valeurs inutilisées
+    };
+  }
+}
 
 describe("Le dépôt des points d'accès", () => {
   const adaptateurDomibus = {};
@@ -10,17 +48,13 @@ describe("Le dépôt des points d'accès", () => {
 
   it("trouve les informations du point d'accès par son nom", () => {
     adaptateurDomibus.trouvePointAcces = (nom) => {
-      const reponse = [{
-        name: 'unNom',
-        identifiers: [{
-          partyId: 'unId',
-          partyIdType: {
-            name: 'partyTypeUrn',
-            value: 'urn:oasis:names:tc:ebcore:partyid-type:unregistered:oots-simulator',
-          },
-        }],
-        // … et d'autres valeurs inutilisées
-      }];
+      const reponse = [
+        new ConstructeurPointAcces()
+          .avecNom(nom)
+          .avecId('unId')
+          .avecTypeIdentifiant('urn:unType')
+          .construis(),
+      ];
 
       try {
         expect(nom).toBe('unNom');
@@ -32,7 +66,7 @@ describe("Le dépôt des points d'accès", () => {
 
     const depot = new DepotPointsAcces(adaptateurDomibus);
     return expect(depot.trouvePointAcces('unNom')).resolves.toEqual({
-      typeIdentifiant: 'urn:oasis:names:tc:ebcore:partyid-type:unregistered:oots-simulator',
+      typeIdentifiant: 'urn:unType',
       id: 'unId',
     });
   });
@@ -46,6 +80,34 @@ describe("Le dépôt des points d'accès", () => {
       .catch((e) => {
         expect(e).toBeInstanceOf(ErreurDestinataireInexistant);
         expect(e.message).toBe("Point d'accès inexistant : unNom");
+      });
+  });
+
+  it("retourne une `ErreurDestinataireInexistant` si aucun nom n'est passé en paramètre", () => {
+    expect.assertions(2);
+    const tousPointsAcces = [new ConstructeurPointAcces().construis()];
+
+    adaptateurDomibus.trouvePointAcces = () => Promise.resolve(tousPointsAcces);
+
+    const depot = new DepotPointsAcces(adaptateurDomibus);
+    return depot.trouvePointAcces()
+      .catch((e) => {
+        expect(e).toBeInstanceOf(ErreurDestinataireInexistant);
+        expect(e.message).toBe('Destinataire non renseigné');
+      });
+  });
+
+  it('retourne une `ErreurDestinataireInexistant` si le nom renseigné est une chaine vide', () => {
+    expect.assertions(2);
+    const tousPointsAcces = [new ConstructeurPointAcces().construis()];
+
+    adaptateurDomibus.trouvePointAcces = () => Promise.resolve(tousPointsAcces);
+
+    const depot = new DepotPointsAcces(adaptateurDomibus);
+    return depot.trouvePointAcces('')
+      .catch((e) => {
+        expect(e).toBeInstanceOf(ErreurDestinataireInexistant);
+        expect(e.message).toBe('Destinataire non renseigné');
       });
   });
 });


### PR DESCRIPTION
Jusqu'à présent, si `nomDestinataire` vaut `undefined` ou chaîne vide, la requête pour obtenir l'identifiant et son type retourne tous les points d'accès, on choisit le premier et on lui envoie un message qui ne lui est pas destiné.

Ce commit corrige le problème.