### PR TITLE
Utilise « HTTP Basic Authentication » pour authentifier les requêtes SOAP envoyées à Domibus

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,5 +12,8 @@ module.exports = {
   overrides: [{
     files: ['src/erreurs.js'],
     rules: { 'max-classes-per-file': ['off'] },
+  }, {
+    files: ['test*/**/*.*js'],
+    rules: { 'no-new': ['off'] },
   }],
 };

--- a/src/adaptateurs/adaptateurDomibus.js
+++ b/src/adaptateurs/adaptateurDomibus.js
@@ -19,21 +19,23 @@ const REPONSE_SUCCES = 'reponseSucces';
 const AdaptateurDomibus = (config = {}) => {
   const annonceur = new EventEmitter();
 
-  const envoieRequeteREST = (chemin, parametres) => {
+  const enteteAuthentificationBasique = () => {
     const jetonEncode = btoa(`${process.env.LOGIN_API_REST}:${process.env.MOT_DE_PASSE_API_REST}`);
-
-    return axios({
-      method: 'get',
-      url: `${urlBase}/${chemin}`,
-      headers: { Authorization: `Basic ${jetonEncode}` },
-      params: parametres,
-    }).then(({ data }) => data);
+    return { Authorization: `Basic ${jetonEncode}` };
   };
+
+  const envoieRequeteREST = (chemin, parametres) => axios({
+    method: 'get',
+    url: `${urlBase}/${chemin}`,
+    headers: enteteAuthentificationBasique(),
+    params: parametres,
+  })
+    .then(({ data }) => data);
 
   const envoieRequeteSOAP = (commande, message) => axios.post(
     `${urlBase}/services/wsplugin/${commande}`,
     message,
-    { headers: { 'Content-Type': 'text/xml' } },
+    { headers: { 'Content-Type': 'text/xml', ...enteteAuthentificationBasique() } },
   );
 
   const envoieMessageDomibus = (messageSOAP) => envoieRequeteSOAP('submitMessage', messageSOAP)

--- a/src/domibus/instructionSOAP.js
+++ b/src/domibus/instructionSOAP.js
@@ -1,0 +1,58 @@
+const ReponseEnvoiMessage = require('./reponseEnvoiMessage');
+const ReponseRecuperationMessage = require('./reponseRecuperationMessage');
+const ReponseRequeteListeMessagesEnAttente = require('./reponseRequeteListeMessagesEnAttente');
+const { ErreurInstructionSOAPInconnue } = require('../erreurs');
+
+const instructions = {
+  ENVOIE_MESSAGE: {
+    libelle: 'submitMessage',
+    classeReponse: ReponseEnvoiMessage,
+  },
+  LISTE_MESSAGES_EN_ATTENTE: {
+    libelle: 'listPendingMessages',
+    classeReponse: ReponseRequeteListeMessagesEnAttente,
+  },
+  RECUPERE_MESSAGE: {
+    libelle: 'retrieveMessage',
+    classeReponse: ReponseRecuperationMessage,
+  },
+};
+
+const libelles = Object.keys(instructions)
+  .reduce((acc, cle) => ({ ...acc, [cle]: instructions[cle].libelle }), {});
+
+class InstructionSOAP {
+  static instructionsExistantes() {
+    return Object.values(libelles);
+  }
+
+  static envoieMessage() {
+    return new InstructionSOAP('submitMessage');
+  }
+
+  static listeMessagesEnAttente() {
+    return new InstructionSOAP('listPendingMessages');
+  }
+
+  static recupereMessage() {
+    return new InstructionSOAP('retrieveMessage');
+  }
+
+  constructor(libelleInstruction) {
+    if (!InstructionSOAP.instructionsExistantes().includes(libelleInstruction)) {
+      throw new ErreurInstructionSOAPInconnue(`Instruction SOAP inconnue: ${libelleInstruction}`);
+    }
+
+    this.libelle = libelleInstruction;
+    this.ClasseReponse = Object.values(instructions)
+      .find(({ libelle }) => libelle === libelleInstruction)
+      .classeReponse;
+  }
+
+  nouvelleReponseDomibus(data) {
+    return new this.ClasseReponse(data);
+  }
+}
+
+Object.assign(InstructionSOAP, libelles);
+module.exports = InstructionSOAP;

--- a/src/erreurs.js
+++ b/src/erreurs.js
@@ -1,11 +1,13 @@
 class ErreurAbsenceReponseDestinataire extends Error {}
 class ErreurAucunMessageDomibusRecu extends Error {}
-class ErreurReponseRequete extends Error {}
+class ErreurInstructionSOAPInconnue extends Error {}
 class ErreurDestinataireInexistant extends Error {}
+class ErreurReponseRequete extends Error {}
 
 module.exports = {
   ErreurAbsenceReponseDestinataire,
   ErreurAucunMessageDomibusRecu,
-  ErreurReponseRequete,
+  ErreurInstructionSOAPInconnue,
   ErreurDestinataireInexistant,
+  ErreurReponseRequete,
 };

--- a/test/domibus/instructionSOAP.spec.js
+++ b/test/domibus/instructionSOAP.spec.js
@@ -1,0 +1,47 @@
+const ConstructeurEnveloppeSOAPAvecPieceJointe = require('../constructeurs/constructeurEnveloppeSOAPAvecPieceJointe');
+const InstructionSOAP = require('../../src/domibus/instructionSOAP');
+const ReponseEnvoiMessage = require('../../src/domibus/reponseEnvoiMessage');
+const ReponseRecuperationMessage = require('../../src/domibus/reponseRecuperationMessage');
+const ReponseRequeteListeMessagesEnAttente = require('../../src/domibus/reponseRequeteListeMessagesEnAttente');
+const { ErreurInstructionSOAPInconnue } = require('../../src/erreurs');
+
+describe('Une instruction SOAP', () => {
+  it("génère une `ErreurInstructionSOAPInconnue` si l'instruction est inconnue", (suite) => {
+    expect(InstructionSOAP.instructionsExistantes()).not.toContain('instructionInconnue');
+
+    try {
+      new InstructionSOAP('instructionInconnue', {});
+      suite("L'instanciation d'une instruction inconnue aurait dû générer une `ErreurInstructionSOAPInconnue`");
+    } catch (e) {
+      expect(e).toBeInstanceOf(ErreurInstructionSOAPInconnue);
+      expect(e.message).toBe('Instruction SOAP inconnue: instructionInconnue');
+      suite();
+    }
+  });
+
+  describe('envoi de message', () => {
+    it('génère une `ReponseEnvoiMessage`', () => {
+      const instruction = InstructionSOAP.envoieMessage();
+      const donnees = {};
+      expect(instruction.nouvelleReponseDomibus(donnees)).toBeInstanceOf(ReponseEnvoiMessage);
+    });
+  });
+
+  describe('liste des messages en attentes', () => {
+    it('génère une `ReponseRequeteListeMessagesEnAttente`', () => {
+      const instruction = InstructionSOAP.listeMessagesEnAttente();
+      const donnees = {};
+      expect(instruction.nouvelleReponseDomibus(donnees))
+        .toBeInstanceOf(ReponseRequeteListeMessagesEnAttente);
+    });
+  });
+
+  describe("recupération d'un message", () => {
+    it('génère une `ReponseRecuperationMessage`', () => {
+      const instruction = InstructionSOAP.recupereMessage();
+      const donnees = new ConstructeurEnveloppeSOAPAvecPieceJointe().construis();
+      expect(instruction.nouvelleReponseDomibus(donnees))
+        .toBeInstanceOf(ReponseRecuperationMessage);
+    });
+  });
+});


### PR DESCRIPTION
Nous voulons pouvoir refuser sur la production la possibilité d'une connexion SOAP « unsecure », et pour cela mettre la variable Domibus `domibus.auth.unsecureLoginAllowed` à `false` (alors que la valeur par défaut est `true`). Cela a pour impact de devoir ajouter un mécanisme d'authentification à l'envoi des requêtes SOAP – d'où cette PR.

On en profite pour poursuivre le nettoyage de `AdaptateurDomibus` et pour déporter dans des classes métiers testables le lien entre le nom de la commande SOAP et la classe métier utilisée pour représenter la réponse Domibus correspondante.