### PR TITLE
Utilise clé privée pour exposer clé publique sous forme d'un JWK Set

### DIFF
--- a/.env.oots.template
+++ b/.env.oots.template
@@ -1,12 +1,15 @@
 AVEC_REQUETE_PIECE_JUSTIFICATIVE= #active l'API /requete/pieceJustificative avec valeur true
+
 DELAI_MAX_ATTENTE_DOMIBUS= # délai maximum d'attente d'une réponse Domibus à une requête envoyée (en millisecondes)
 IDENTIFIANT_EXPEDITEUR_DOMIBUS= # identifiant expéditeur Domibus
 SUFFIXE_IDENTIFIANTS_DOMIBUS= # suffixe à ajouter dans les trames EBMS, ex. oots.eu
 TYPE_IDENTIFIANT_EXPEDITEUR_DOMIBUS= # type d'identifiant expéditeur Domibus
 URL_BASE_DOMIBUS= # URL instance Domibus, ex. https://domibus.gouv.fr
+
+CLE_PRIVEE_JWK_EN_BASE64= # Cle privée utilisée pour déchiffrer les infos utilisateur provenant de eIDAS (données au format JWK, chiffrées en base64)
 URL_OOTS_FRANCE= # URL Serveur OOTS-France, ex. https://oots.gouv.fr
 
-LOGIN_API_REST= #Login utilisé pour accéder à l'API REST de DOMIBUS
-MOT_DE_PASSE_API_REST= #Mot de passe utilisé pour accéder à l'API REST de DOMIBUS
+LOGIN_API_REST= # Login utilisé pour accéder à l'API REST de DOMIBUS
+MOT_DE_PASSE_API_REST= # Mot de passe utilisé pour accéder à l'API REST de DOMIBUS
 
-JSON_WEB_KEY_SET=#Ensemble de clés utilisé par le chiffrement pour openID Connect, au format JSON (exemple : https://fsp1v2.integ01.fcp.fournisseur-de-service.fr/client/.well-known/keys) puis passé en base64
+

--- a/server.js
+++ b/server.js
@@ -1,5 +1,6 @@
 const EcouteurDomibus = require('./src/ecouteurDomibus');
 const OOTS_FRANCE = require('./src/ootsFrance');
+const adaptateurChiffrement = require('./src/adaptateurs/adaptateurChiffrement');
 const AdaptateurDomibus = require('./src/adaptateurs/adaptateurDomibus');
 const adaptateurEnvironnement = require('./src/adaptateurs/adaptateurEnvironnement');
 const adaptateurUUID = require('./src/adaptateurs/adaptateurUUID');
@@ -11,6 +12,7 @@ const depotPointsAcces = new DepotPointsAcces(adaptateurDomibus);
 const ecouteurDomibus = new EcouteurDomibus({ adaptateurDomibus, intervalleEcoute: 1000 });
 
 const serveur = OOTS_FRANCE.creeServeur({
+  adaptateurChiffrement,
   adaptateurDomibus,
   adaptateurEnvironnement,
   adaptateurUUID,

--- a/src/adaptateurs/adaptateurChiffrement.js
+++ b/src/adaptateurs/adaptateurChiffrement.js
@@ -1,0 +1,5 @@
+const crypto = require('crypto');
+
+const cleHachage = (chaine) => crypto.createHash('md5').update(chaine).digest('hex');
+
+module.exports = { cleHachage };

--- a/src/adaptateurs/adaptateurEnvironnement.js
+++ b/src/adaptateurs/adaptateurEnvironnement.js
@@ -1,5 +1,5 @@
 const avecRequetePieceJustificative = () => process.env.AVEC_REQUETE_PIECE_JUSTIFICATIVE === 'true';
 
-const clesChiffrement = () => atob(process.env.JSON_WEB_KEY_SET);
+const clePriveeJWK = () => JSON.parse(atob(process.env.CLE_PRIVEE_JWK_EN_BASE64));
 
-module.exports = { avecRequetePieceJustificative, clesChiffrement };
+module.exports = { avecRequetePieceJustificative, clePriveeJWK };

--- a/src/ootsFrance.js
+++ b/src/ootsFrance.js
@@ -9,6 +9,7 @@ const RequeteJustificatif = require('./ebms/requeteJustificatif');
 
 const creeServeur = (config) => {
   const {
+    adaptateurChiffrement,
     adaptateurDomibus,
     adaptateurEnvironnement,
     adaptateurUUID,
@@ -92,9 +93,22 @@ const creeServeur = (config) => {
   });
 
   app.get('/auth/cles_publiques', (_requete, reponse) => {
+    const { kty, n, e } = adaptateurEnvironnement.clePriveeJWK();
+    const idClePublique = adaptateurChiffrement.cleHachage(n);
+
+    const clePubliqueDansJWKSet = {
+      keys: [{
+        kid: idClePublique,
+        use: 'enc',
+        kty,
+        e,
+        n,
+      }],
+    };
+
     reponse.set('Content-Type', 'application/json');
     reponse.status(200)
-      .send(adaptateurEnvironnement.clesChiffrement());
+      .send(clePubliqueDansJWKSet);
   });
 
   const arreteEcoute = (suite) => serveur.close(suite);


### PR DESCRIPTION
Ainsi, on limite les risques d'utiliser une clé privée incohérente avec la clé publique utilisée pour chiffrer les informations utilisateur en provenance d'eIDAS.

(Note : il faudra mettre à jour les variables d'environnement au déploiement en préprod.)