### PR TITLE
Récupère informations utilisateurs depuis FC+

### DIFF
--- a/.env.oots.template
+++ b/.env.oots.template
@@ -6,10 +6,13 @@ SUFFIXE_IDENTIFIANTS_DOMIBUS= # suffixe à ajouter dans les trames EBMS, ex. oot
 TYPE_IDENTIFIANT_EXPEDITEUR_DOMIBUS= # type d'identifiant expéditeur Domibus
 URL_BASE_DOMIBUS= # URL instance Domibus, ex. https://domibus.gouv.fr
 
+IDENTIFIANT_CLIENT_FCPLUS= # identifiant d'accès au serveur FC+
+SECRET_CLIENT_FCPLUS= # secret d'accès au serveur FC+
+URL_CONFIGURATION_OPEN_ID_FCPLUS= # URL accès aux informations de configuration Open ID de FranceConnect+
+
 CLE_PRIVEE_JWK_EN_BASE64= # Cle privée utilisée pour déchiffrer les infos utilisateur provenant de eIDAS (données au format JWK, chiffrées en base64)
 URL_OOTS_FRANCE= # URL Serveur OOTS-France, ex. https://oots.gouv.fr
+URL_REDIRECTION_CONNEXION= # URL redirection après authentification FranceConnect+
 
 LOGIN_API_REST= # Login utilisé pour accéder à l'API REST de DOMIBUS
 MOT_DE_PASSE_API_REST= # Mot de passe utilisé pour accéder à l'API REST de DOMIBUS
-
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^1.6.0",
         "express": "^4.18.2",
         "fast-xml-parser": "^4.2.5",
+        "jose": "^5.2.0",
         "nodemon": "^3.0.1",
         "uuid": "^9.0.0"
       },
@@ -4323,6 +4324,14 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.2.0.tgz",
+      "integrity": "sha512-oW3PCnvyrcm1HMvGTzqjxxfnEs9EoFOFWi2HsEGhlFVOXxTE3K9GKWVMFoFw06yPUqwpvEWic1BmtUZBI/tIjw==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "axios": "^1.6.0",
     "express": "^4.18.2",
     "fast-xml-parser": "^4.2.5",
+    "jose": "^5.2.0",
     "nodemon": "^3.0.1",
     "uuid": "^9.0.0"
   }

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ const OOTS_FRANCE = require('./src/ootsFrance');
 const adaptateurChiffrement = require('./src/adaptateurs/adaptateurChiffrement');
 const AdaptateurDomibus = require('./src/adaptateurs/adaptateurDomibus');
 const adaptateurEnvironnement = require('./src/adaptateurs/adaptateurEnvironnement');
+const adaptateurFranceConnectPlus = require('./src/adaptateurs/adaptateurFranceConnectPlus');
 const adaptateurUUID = require('./src/adaptateurs/adaptateurUUID');
 const horodateur = require('./src/adaptateurs/horodateur');
 const DepotPointsAcces = require('./src/depots/depotPointsAcces');
@@ -15,6 +16,7 @@ const serveur = OOTS_FRANCE.creeServeur({
   adaptateurChiffrement,
   adaptateurDomibus,
   adaptateurEnvironnement,
+  adaptateurFranceConnectPlus,
   adaptateurUUID,
   depotPointsAcces,
   ecouteurDomibus,

--- a/src/adaptateurs/adaptateurEnvironnement.js
+++ b/src/adaptateurs/adaptateurEnvironnement.js
@@ -2,4 +2,17 @@ const avecRequetePieceJustificative = () => process.env.AVEC_REQUETE_PIECE_JUSTI
 
 const clePriveeJWK = () => JSON.parse(atob(process.env.CLE_PRIVEE_JWK_EN_BASE64));
 
-module.exports = { avecRequetePieceJustificative, clePriveeJWK };
+const parametresRequeteJeton = () => ({
+  client_id: process.env.IDENTIFIANT_CLIENT_FCPLUS,
+  client_secret: process.env.SECRET_CLIENT_FCPLUS,
+  redirect_uri: process.env.URL_REDIRECTION_CONNEXION,
+});
+
+const urlConfigurationOpenIdFCPlus = () => process.env.URL_CONFIGURATION_OPEN_ID_FCPLUS;
+
+module.exports = {
+  avecRequetePieceJustificative,
+  clePriveeJWK,
+  parametresRequeteJeton,
+  urlConfigurationOpenIdFCPlus,
+};

--- a/src/adaptateurs/adaptateurFranceConnectPlus.js
+++ b/src/adaptateurs/adaptateurFranceConnectPlus.js
@@ -1,0 +1,46 @@
+const axios = require('axios');
+const jose = require('jose');
+
+const adaptateurEnvironnement = require('./adaptateurEnvironnement');
+
+const configurationOpenIdFranceConnectPlus = axios
+  .get(adaptateurEnvironnement.urlConfigurationOpenIdFCPlus())
+  .then(({ data }) => data);
+
+const parametresRequeteJeton = (code) => Object.assign(
+  adaptateurEnvironnement.parametresRequeteJeton(),
+  { code, grant_type: 'authorization_code' },
+);
+
+const recupereJetonAcces = (code) => configurationOpenIdFranceConnectPlus
+  .then(({ token_endpoint: urlRecuperationJetonAcces }) => (
+    axios.post(
+      urlRecuperationJetonAcces,
+      parametresRequeteJeton(code),
+      { headers: { 'content-type': 'application/x-www-form-urlencoded' } },
+    )
+  ))
+  .then(({ data: { access_token: jetonAcces } }) => jetonAcces);
+
+const recupereInfosUtilisateurChiffrees = (jeton) => configurationOpenIdFranceConnectPlus
+  .then(({ userinfo_endpoint: urlRecuperationInfosUtilisateur }) => (
+    axios.get(
+      urlRecuperationInfosUtilisateur,
+      { headers: { Authorization: `Bearer ${jeton}` } },
+    )
+  ))
+  .then(({ data }) => data);
+
+const dechiffreInfosUtilisateur = (infos) => jose
+  .importJWK(adaptateurEnvironnement.clePriveeJWK())
+  .then((clePrivee) => jose.compactDecrypt(infos, clePrivee))
+  .then(({ plaintext }) => {
+    const payload = plaintext.toString().split('.')[1];
+    return JSON.parse(atob(payload));
+  });
+
+const recupereInfosUtilisateur = (code) => recupereJetonAcces(code)
+  .then(recupereInfosUtilisateurChiffrees)
+  .then(dechiffreInfosUtilisateur);
+
+module.exports = { recupereInfosUtilisateur };

--- a/src/ootsFrance.js
+++ b/src/ootsFrance.js
@@ -12,6 +12,7 @@ const creeServeur = (config) => {
     adaptateurChiffrement,
     adaptateurDomibus,
     adaptateurEnvironnement,
+    adaptateurFranceConnectPlus,
     adaptateurUUID,
     depotPointsAcces,
     ecouteurDomibus,
@@ -28,6 +29,20 @@ const creeServeur = (config) => {
   app.post('/admin/demarrageEcouteDomibus', (_requete, reponse) => {
     ecouteurDomibus.ecoute();
     reponse.send({ etatEcouteur: ecouteurDomibus.etat() });
+  });
+
+  app.get('/auth/fcplus/connexion', (requete, reponse) => {
+    const { code, state } = requete.query;
+    if (typeof state === 'undefined' || state === '') {
+      reponse.status(400).json({ erreur: "Paramètre 'state' absent de la requête" });
+    } else if (typeof code === 'undefined' || code === '') {
+      reponse.status(400).json({ erreur: "Paramètre 'code' absent de la requête" });
+    } else {
+      adaptateurFranceConnectPlus.recupereInfosUtilisateur(code)
+        .then((infos) => {
+          reponse.json(infos);
+        });
+    }
   });
 
   app.get('/ebms/entetes/requeteJustificatif', (requete, reponse) => {


### PR DESCRIPTION
Prochaines étapes :
- Vérifier signature des infos reçues
- Vérifier cohérence du `state`
- Conserver les infos dans la session
- Rediriger vers une mire d'authentification si infos absentes

(Note : il faut ajouter des variables d'environnement avant de déployer.)