### PR TITLE
Vérifie la signature du JWT reçu

### DIFF
--- a/mockFCPlus.js
+++ b/mockFCPlus.js
@@ -3,10 +3,9 @@ const jose = require('jose');
 
 const adaptateurChiffrement = require('./src/adaptateurs/adaptateurChiffrement');
 
-const app = express();
-const port = 4000;
+const JETON_CAS_SIGNATURE_INVALIDE = 'jetonCasSignatureInvalide';
 
-const jwk = {
+const jwkValide = {
   kty: 'RSA',
   n: 'whYOFK2Ocbbpb_zVypi9SeKiNUqKQH0zTKN1-6fpCTu6ZalGI82s7XK3tan4dJt90ptUPKD2zvxqTzFNfx4HHHsrYCf2-FMLn1VTJfQazA2BvJqAwcpW1bqRUEty8tS_Yv4hRvWfQPcc2Gc3-_fQOOW57zVy-rNoJc744kb30NjQxdGp03J2S3GLQu7oKtSDDPooQHD38PEMNnITf0pj-KgDPjymkMGoJlO3aKppsjfbt_AH6GGdRghYRLOUwQU-h-ofWHR3lbYiKtXPn5dN24kiHy61e3VAQ9_YAZlwXC_99GGtw_NpghFAuM4P1JDn0DppJldy3PGFC0GfBCZASw',
   e: 'AQAB',
@@ -18,7 +17,24 @@ const jwk = {
   qi: 'iYltkV_4PmQDfZfGFpzn2UtYEKyhy-9t3Vy8Mw2VHLAADKGwJvVK5ficQAr2atIF1-agXY2bd6KV-w52zR8rmZfTr0gobzYIyqHczOm13t7uXJv2WygY7QEC2OGjdxa2Fr9RnvS99ozMa5nomZBqTqT7z5QV33czjPRCjvg6FcE',
 };
 
+const jwkInvalide = {
+  kty: 'RSA',
+  n: 'y6CltudeoaMikeSwChFGWePEDUJevbb-pb2o0aDREQ_7jqfwUR6uCGU_eXmEfIor-f3afasfBmbpiKIHSPosUFSbpImkBoCwd5W8miSBwhWIxYIgUnsjGu4nfaM9i2NtHc4EGG8SM5yQd6i6Eb1q2KTbjwIzsPAMTwnrGmYmeFVZPK6wdtDYKuXzrmt6CcBZu3duG4Y0uhz-DhssVgZQZIMyn6mEnep-XsvKvRjNU7Gl26woWnHueIlcG0e4WaoPxbc5Xd1ZbT7Bu6M8N3FjHHS6FrXIqeYtrzJOtwDe37IOsuR4d87n_cNKf311fXK6iYYimoSOQwsSAG6WgalfNw',
+  e: 'AQAB',
+  d: 'W8BlKwcR0s9JEmfzEnY6NuK0Qi03t1AvacsNuHc3_PIwrVTqqgKi9FF6ymeA1QUFT72cp6dlcWMJs3Eeyzk-omudPgRvDicKXLfxpZrxhNxjJmu92Kx3YvkQfkIBxz7judxMaB4UG4FebyxtuvSYokmWTNf3JrDjOvIDJ4ADsZAlb3QXzJwRzKMzYMN6PAt5CW9CEPqR_nwu9p_zlUFtC4qDXitfmSpLO5quZTpDJrBYWsnHdj77pe3knqcjw8lTGLCojSDmCydbG7hkz3Xq31-eY0YFOPJgWcbQMkLiyF0y5GsF1CjRKFNywgfxljzRzEiLCs4Ihof0phkX-vqT4Q',
+  p: '8coKPaGjRE9q-xjVRLfAWpJ9aW6D6xUVGeC26jJu9D2nPyG3mpORzn72EtP_VxsHK7KQ4DnNgvT000-mSeiKkjufxTss7N2-TJUupkc0IJpr5QjDXP3fJcplJGyF6BgBVaUuJJWytRrrBrdQBtCKv5dNkhdDNZFhIB7TYPGs5ak',
+  q: '15htNxigCp5aq23f5507wKFamM_sOZSKYldTNod8XJOtnYXT1ZOY7AWUwHWIs3glU8xlw9GX1VJcWn9YGqe6rYgd_yxVglq2PR7vVhUuT7Dym0r5Z1Q605DAqh3tyVfFkegxYB0kNwmSw3LHvxsxCyXeaUOzeRO5oDM4SyXjad8',
+  dp: 'Eeh69bGhHBAdxldChIJvlsW-0C5FSwYWuAHyyknN-f0PBBgFN0eyxu6UXzSgdt0jnNLu9AyT8h0efQArOtIkYUxVOxB09V4_GAD8oYgojjmhwCb0AVE0U-I3t4jqKhSNFMDVOBR2Vf-WZLrzDG4puKMGNcnPSopn_S8LTOTZf3E',
+  dq: 'vuFNkQJUcBJT5IObQc2MIbi6JaGxXCmPfBIkspqyGKUHiff63ZWYRx-J2_wz0_ID2nWVhBIFg_Evo1AsCS2HsixZopr1-jumLec9r9GA9z2LDsMKndmNW9NFQVjONv1nBw-054vljHUFY9Yz05eXjG8yw7AVLpWwO44dwSsCdbE',
+  qi: 'tA3h9_ecg1pu9zenGhdkW9lY7HqU3a41ROPQxYVX8rVybgwiO7MlqBQmy2zgezB5NQfzIgeWMtgThemN5RiQ3bunGRBOHL9PFjMo_aGO3hZkj93EdoxZBiIlLwJX11yxmMBC05jojVR-2XjX9Eijs5xmFdrjkngmwlAhbYyz6M0',
+};
+
 const ootsJWK = JSON.parse(atob(process.env.CLE_PRIVEE_JWK_EN_BASE64));
+
+const port = 4000;
+const app = express();
+
+app.use(express.urlencoded({ extended: true }));
 
 app.get('/', (_requete, reponse) => {
   reponse.json({
@@ -28,12 +44,14 @@ app.get('/', (_requete, reponse) => {
   });
 });
 
-app.post('/jeton', (_requete, reponse) => {
-  reponse.json({ access_token: 'unJeton' });
+app.post('/jeton', (requete, reponse) => {
+  const { code } = requete.body;
+  const jeton = (code === 'XXX') ? JETON_CAS_SIGNATURE_INVALIDE : 'unJeton';
+  reponse.json({ access_token: jeton });
 });
 
 app.get('/jwks', (_requete, reponse) => {
-  const { kty, n, e } = jwk;
+  const { kty, n, e } = jwkValide;
 
   reponse.json({
     keys: [{
@@ -45,7 +63,10 @@ app.get('/jwks', (_requete, reponse) => {
   });
 });
 
-app.get('/userinfo', (_requete, reponse) => {
+app.get('/userinfo', (requete, reponse) => {
+  const jeton = requete.headers.authorization.match(/Bearer (.*)/)[1];
+  const cleSignature = (jeton === JETON_CAS_SIGNATURE_INVALIDE) ? jwkInvalide : jwkValide;
+
   const envoieInfos = (infos) => {
     const headerJWT = {
       alg: 'RS256',
@@ -60,7 +81,7 @@ app.get('/userinfo', (_requete, reponse) => {
       aud: process.env.IDENTIFIANT_CLIENT_FCPLUS,
     };
 
-    jose.importJWK(jwk)
+    jose.importJWK(cleSignature)
       .then((clePrivee) => new jose.SignJWT(infos)
         .setProtectedHeader(headerJWT)
         .setIssuedAt()

--- a/mockFCPlus.js
+++ b/mockFCPlus.js
@@ -22,6 +22,7 @@ const ootsJWK = JSON.parse(atob(process.env.CLE_PRIVEE_JWK_EN_BASE64));
 
 app.get('/', (_requete, reponse) => {
   reponse.json({
+    jwks_uri: `${process.env.URL_BASE_MOCK_FCPLUS}/jwks`,
     token_endpoint: `${process.env.URL_BASE_MOCK_FCPLUS}/jeton`,
     userinfo_endpoint: `${process.env.URL_BASE_MOCK_FCPLUS}/userinfo`,
   });
@@ -29,6 +30,19 @@ app.get('/', (_requete, reponse) => {
 
 app.post('/jeton', (_requete, reponse) => {
   reponse.json({ access_token: 'unJeton' });
+});
+
+app.get('/jwks', (_requete, reponse) => {
+  const { kty, n, e } = jwk;
+
+  reponse.json({
+    keys: [{
+      use: 'sig',
+      kty,
+      n,
+      e,
+    }],
+  });
 });
 
 app.get('/userinfo', (_requete, reponse) => {

--- a/src/adaptateurs/adaptateurFranceConnectPlus.js
+++ b/src/adaptateurs/adaptateurFranceConnectPlus.js
@@ -31,13 +31,15 @@ const recupereInfosUtilisateurChiffrees = (jeton) => configurationOpenIdFranceCo
   ))
   .then(({ data }) => data);
 
+const verifieSignatureJWT = (jwt) => configurationOpenIdFranceConnectPlus
+  .then(({ jwks_uri: urlJWKS }) => jose.createRemoteJWKSet(new URL(urlJWKS)))
+  .then((jwks) => jose.jwtVerify(jwt, jwks))
+  .then(({ payload }) => payload);
+
 const dechiffreInfosUtilisateur = (infos) => jose
   .importJWK(adaptateurEnvironnement.clePriveeJWK())
   .then((clePrivee) => jose.compactDecrypt(infos, clePrivee))
-  .then(({ plaintext }) => {
-    const payload = plaintext.toString().split('.')[1];
-    return JSON.parse(atob(payload));
-  });
+  .then(({ plaintext }) => verifieSignatureJWT(plaintext));
 
 const recupereInfosUtilisateur = (code) => recupereJetonAcces(code)
   .then(recupereInfosUtilisateurChiffrees)

--- a/src/adaptateurs/adaptateurFranceConnectPlus.js
+++ b/src/adaptateurs/adaptateurFranceConnectPlus.js
@@ -2,6 +2,7 @@ const axios = require('axios');
 const jose = require('jose');
 
 const adaptateurEnvironnement = require('./adaptateurEnvironnement');
+const { ErreurEchecAuthentification } = require('../erreurs');
 
 const configurationOpenIdFranceConnectPlus = axios
   .get(adaptateurEnvironnement.urlConfigurationOpenIdFCPlus())
@@ -43,6 +44,7 @@ const dechiffreInfosUtilisateur = (infos) => jose
 
 const recupereInfosUtilisateur = (code) => recupereJetonAcces(code)
   .then(recupereInfosUtilisateurChiffrees)
-  .then(dechiffreInfosUtilisateur);
+  .then(dechiffreInfosUtilisateur)
+  .catch((e) => Promise.reject(new ErreurEchecAuthentification(e.message)));
 
 module.exports = { recupereInfosUtilisateur };

--- a/src/erreurs.js
+++ b/src/erreurs.js
@@ -1,13 +1,15 @@
 class ErreurAbsenceReponseDestinataire extends Error {}
 class ErreurAucunMessageDomibusRecu extends Error {}
-class ErreurInstructionSOAPInconnue extends Error {}
 class ErreurDestinataireInexistant extends Error {}
+class ErreurEchecAuthentification extends Error {}
+class ErreurInstructionSOAPInconnue extends Error {}
 class ErreurReponseRequete extends Error {}
 
 module.exports = {
   ErreurAbsenceReponseDestinataire,
   ErreurAucunMessageDomibusRecu,
-  ErreurInstructionSOAPInconnue,
   ErreurDestinataireInexistant,
+  ErreurEchecAuthentification,
+  ErreurInstructionSOAPInconnue,
   ErreurReponseRequete,
 };

--- a/src/ootsFrance.js
+++ b/src/ootsFrance.js
@@ -39,9 +39,10 @@ const creeServeur = (config) => {
       reponse.status(400).json({ erreur: "Paramètre 'code' absent de la requête" });
     } else {
       adaptateurFranceConnectPlus.recupereInfosUtilisateur(code)
-        .then((infos) => {
-          reponse.json(infos);
-        });
+        .then((infos) => reponse.json(infos))
+        .catch((e) => reponse.status(502).json({
+          erreur: `Échec authentification (${e.message})`,
+        }));
     }
   });
 

--- a/test/ootsFrance.spec.js
+++ b/test/ootsFrance.spec.js
@@ -1,7 +1,7 @@
 const axios = require('axios');
 
 const { parseXML } = require('./ebms/utils');
-const { ErreurAbsenceReponseDestinataire } = require('../src/erreurs');
+const { ErreurAbsenceReponseDestinataire, ErreurEchecAuthentification } = require('../src/erreurs');
 const OOTS_FRANCE = require('../src/ootsFrance');
 
 describe('Le serveur OOTS France', () => {
@@ -82,6 +82,20 @@ describe('Le serveur OOTS France', () => {
         .catch(({ response }) => {
           expect(response.status).toBe(400);
           expect(response.data).toEqual({ erreur: "Paramètre 'state' absent de la requête" });
+        });
+    });
+
+    it("sert une erreur HTTP 502 (Bad Gateway) quand l'authentification échoue", () => {
+      expect.assertions(2);
+
+      adaptateurFranceConnectPlus.recupereInfosUtilisateur = () => (
+        Promise.reject(new ErreurEchecAuthentification('Oups'))
+      );
+
+      return axios.get(`http://localhost:${port}/auth/fcplus/connexion?code=unCode&state=unState`)
+        .catch(({ response }) => {
+          expect(response.status).toBe(502);
+          expect(response.data).toEqual({ erreur: 'Échec authentification (Oups)' });
         });
     });
   });


### PR DESCRIPTION
On peut simuler la réception d'un JWT avec signature invalide en passant comme paramètre de requête `code=XXX`.