### PR TITLE
Injecte un identifiant eIDAS dans requête Domibus

### DIFF
--- a/.env.oots.template
+++ b/.env.oots.template
@@ -13,6 +13,7 @@ URL_CONFIGURATION_OPEN_ID_FCPLUS= # URL accès aux informations de configuration
 
 CLE_PRIVEE_JWK_EN_BASE64= # Cle privée utilisée pour déchiffrer les infos utilisateur provenant de eIDAS (données au format JWK, chiffrées en base64)
 SECRET_JETON_SESSION= # secret utilisé pour chiffrer et déchiffrer le jeton stocké dans le cookie de session
+IDENTIFIANT_EIDAS= # identifiant eIDAS injecté dans les requêtes (tant qu'on ne sait pas le récupérer)
 URL_OOTS_FRANCE= # URL Serveur OOTS-France, ex. https://oots.gouv.fr
 URL_REDIRECTION_CONNEXION= # URL redirection après authentification FranceConnect+
 

--- a/src/api/pieceJustificative.js
+++ b/src/api/pieceJustificative.js
@@ -25,6 +25,7 @@ const pieceJustificative = (
       codeDemarche,
       destinataire,
       idConversation,
+      identifiantEIDAS: process.env.IDENTIFIANT_EIDAS,
       previsualisationRequise: (previsualisationRequise === 'true' || previsualisationRequise === ''),
     }))
     .then(() => Promise.any([

--- a/src/ebms/requeteJustificatif.js
+++ b/src/ebms/requeteJustificatif.js
@@ -10,12 +10,14 @@ class RequeteJustificatif extends Message {
       codeDemarche = 'T1',
       destinataire = {},
       idConversation = config.adaptateurUUID.genereUUID(),
+      identifiantEIDAS = 'DK/DE/123123123',
       previsualisationRequise = false,
     } = {},
   ) {
     super(config, { destinataire, idConversation });
 
     this.codeDemarche = codeDemarche;
+    this.identifiantEIDAS = identifiantEIDAS;
     this.previsualisationRequise = previsualisationRequise;
   }
 
@@ -108,7 +110,7 @@ class RequeteJustificatif extends Message {
       <rim:SlotValue xsi:type="rim:AnyValueType">
         <sdg:Person>
           <sdg:LevelOfAssurance>High</sdg:LevelOfAssurance>
-          <sdg:Identifier schemeID="eidas">DK/DE/123123123</sdg:Identifier>
+          <sdg:Identifier schemeID="eidas">${this.identifiantEIDAS}</sdg:Identifier>
           <sdg:FamilyName>Smith</sdg:FamilyName>
           <sdg:GivenName>Jonas</sdg:GivenName>
           <sdg:DateOfBirth>1999-03-01</sdg:DateOfBirth>

--- a/test/api/pieceJustificative.spec.js
+++ b/test/api/pieceJustificative.spec.js
@@ -60,6 +60,30 @@ describe('Le requêteur de pièce justificative', () => {
     return pieceJustificative(config, requete, reponse);
   });
 
+  describe('quand `process.env.IDENTIFIANT_EIDAS` vaut `FR/BE/123456789`', () => {
+    let identifiantTemporaire;
+
+    beforeEach(() => {
+      identifiantTemporaire = process.env.IDENTIFIANT_EIDAS;
+      process.env.IDENTIFIANT_EIDAS = 'FR/BE/123456789';
+    });
+
+    afterEach(() => {
+      process.env.IDENTIFIANT_EIDAS = identifiantTemporaire;
+    });
+
+    it('utilise cet identifiant', () => {
+      adaptateurDomibus.envoieMessageRequete = ({ identifiantEIDAS }) => {
+        try {
+          expect(identifiantEIDAS).toEqual('FR/BE/123456789');
+          return Promise.resolve();
+        } catch (e) { return Promise.reject(e); }
+      };
+
+      return pieceJustificative(config, requete, reponse);
+    });
+  });
+
   it('utilise un identifiant de conversation', () => {
     adaptateurUUID.genereUUID = () => '11111111-1111-1111-1111-111111111111';
 

--- a/test/ebms/requeteJustificatif.spec.js
+++ b/test/ebms/requeteJustificatif.spec.js
@@ -64,4 +64,15 @@ describe("La vue du message de requête d'un justificatif", () => {
     const codeDemarche = valeurSlot('Procedure', xml.QueryRequest);
     expect(codeDemarche.LocalizedString['@_value']).toBe('T3');
   });
+
+  it("injecte l'identifiant eIDAS spécifié en variable d'environnement", () => {
+    const requeteJustificatif = new RequeteJustificatif(
+      configurationRequete,
+      { identifiantEIDAS: 'BE/FR/123456789' },
+    );
+    const xml = parseXML(requeteJustificatif.corpsMessageEnXML());
+
+    const personne = valeurSlot('NaturalPerson', xml.QueryRequest.Query);
+    expect(personne.Person.Identifier['#text']).toBe('BE/FR/123456789');
+  });
 });

--- a/test/ebms/utils.js
+++ b/test/ebms/utils.js
@@ -18,7 +18,8 @@ const valeurSlot = (nomSlot, scopeRecherche) => {
   verifiePresenceSlot(nomSlot, scopeRecherche);
   const sectionSlots = scopeRecherche.Slot;
   const slots = [].concat(sectionSlots);
-  return slots.find((s) => s['@_name'] === nomSlot).SlotValue.Value;
+  const slot = slots.find((s) => s['@_name'] === nomSlot).SlotValue;
+  return (slot['@_type'] === 'rim:AnyValueType') ? slot : slot.Value;
 };
 
 module.exports = { parseXML, verifiePresenceSlot, valeurSlot };


### PR DESCRIPTION
… Afin de permettre les tests avec les autres états membres, à un moment où ne ne savons pas encore récupérer l'identifiant depuis le nœud eIDAS.