### PR TITLE
[CORRECTION] utilise valeurs correctes pour propriétés `originalSender` et `finalRecipient`

### DIFF
--- a/src/ebms/entete.js
+++ b/src/ebms/entete.js
@@ -51,8 +51,8 @@ class Entete {
       ${baliseIdConversation}
     </eb:CollaborationInfo>
     <eb:MessageProperties>
-      <eb:Property name="originalSender" type="urn:oasis:names:tc:ebcore:partyid-type:unregistered">C1</eb:Property>
-      <eb:Property name="finalRecipient" type="urn:oasis:names:tc:ebcore:partyid-type:unregistered">C4</eb:Property>
+      <eb:Property name="originalSender" type="urn:oasis:names:tc:ebcore:partyid-type:unregistered:FR">C1</eb:Property>
+      <eb:Property name="finalRecipient" type="urn:oasis:names:tc:ebcore:partyid-type:unregistered:oots">C4</eb:Property>
     </eb:MessageProperties>
     <eb:PayloadInfo>
       <eb:PartInfo href="${this.idPayload}">

--- a/test/ebms/enteteRequete.spec.js
+++ b/test/ebms/enteteRequete.spec.js
@@ -98,7 +98,7 @@ describe("l'entête EBMS de requête", () => {
       const proprietes = xml.Messaging.UserMessage.MessageProperties.Property;
       const expediteur = proprietes.find((p) => p['@_name'] === 'originalSender');
 
-      expect(expediteur['@_type']).toEqual('urn:oasis:names:tc:ebcore:partyid-type:unregistered');
+      expect(expediteur['@_type']).toEqual('urn:oasis:names:tc:ebcore:partyid-type:unregistered:FR');
       expect(expediteur['#text']).toEqual('C1');
     });
 
@@ -108,7 +108,7 @@ describe("l'entête EBMS de requête", () => {
       const proprietes = xml.Messaging.UserMessage.MessageProperties.Property;
       const expediteur = proprietes.find((p) => p['@_name'] === 'finalRecipient');
 
-      expect(expediteur['@_type']).toEqual('urn:oasis:names:tc:ebcore:partyid-type:unregistered');
+      expect(expediteur['@_type']).toEqual('urn:oasis:names:tc:ebcore:partyid-type:unregistered:oots');
       expect(expediteur['#text']).toEqual('C4');
     });
   });


### PR DESCRIPTION
… Afin de satisfaire les nouvelles règles de validation.