### PR TITLE
Ajoute route `GET /auth/fcplus/deconnexion`

### DIFF
--- a/src/api/deconnexionFCPlus.js
+++ b/src/api/deconnexionFCPlus.js
@@ -1,0 +1,6 @@
+const deconnexionFCPlus = (requete, reponse) => {
+  requete.session = null;
+  reponse.redirect('/');
+};
+
+module.exports = deconnexionFCPlus;

--- a/src/routes/routesAuth.js
+++ b/src/routes/routesAuth.js
@@ -42,6 +42,11 @@ const routesAuth = (config) => {
     }
   });
 
+  routes.get('/fcplus/deconnexion', (requete, reponse) => {
+    requete.session = null;
+    reponse.end('déconnecté !');
+  });
+
   return routes;
 };
 

--- a/src/routes/routesAuth.js
+++ b/src/routes/routesAuth.js
@@ -1,6 +1,7 @@
 const express = require('express');
 
 const connexionFCPlus = require('../api/connexionFCPlus');
+const deconnexionFCPlus = require('../api/deconnexionFCPlus');
 
 const routesAuth = (config) => {
   const { adaptateurChiffrement, adaptateurEnvironnement, adaptateurFranceConnectPlus } = config;
@@ -42,10 +43,9 @@ const routesAuth = (config) => {
     }
   });
 
-  routes.get('/fcplus/deconnexion', (requete, reponse) => {
-    requete.session = null;
-    reponse.end('déconnecté !');
-  });
+  routes.get('/fcplus/deconnexion', (requete, reponse) => (
+    deconnexionFCPlus(requete, reponse)
+  ));
 
   return routes;
 };

--- a/test/api/deconnexionFCPlus.spec.js
+++ b/test/api/deconnexionFCPlus.spec.js
@@ -1,0 +1,19 @@
+const deconnexionFCPlus = require('../../src/api/deconnexionFCPlus');
+
+describe('Le requêteur de déconnexion FC+', () => {
+  const requete = {};
+  const reponse = {};
+
+  beforeEach(() => {
+    requete.session = {};
+    reponse.redirect = () => Promise.resolve();
+    reponse.end = () => Promise.resolve();
+  });
+
+  it('vide le cookie de session', () => {
+    requete.session.jeton = 'unJeton';
+
+    deconnexionFCPlus(requete, reponse);
+    expect(requete.session).toBe(null);
+  });
+});

--- a/test/routes/routesAuth.spec.js
+++ b/test/routes/routesAuth.spec.js
@@ -103,15 +103,9 @@ describe('Le serveur des routes `/auth`', () => {
   });
 
   describe('sur GET /auth/fcplus/deconnexion', () => {
-    it('vide le cookie de session', () => (
+    it('redirige vers page accueil', () => (
       axios.get(`http://localhost:${port}/auth/fcplus/deconnexion`)
-        .then((reponse) => {
-          expect(reponse.headers).toHaveProperty('set-cookie');
-          const valeurEnteteSetCookie = reponse
-            .headers['set-cookie']
-            .find((h) => h.match(/jeton/));
-          expect(valeurEnteteSetCookie).toContain('jeton=;');
-        })
+        .then((reponse) => expect(reponse.request.path).toBe('/'))
         .catch(leveErreur)
     ));
   });

--- a/test/routes/routesAuth.spec.js
+++ b/test/routes/routesAuth.spec.js
@@ -101,4 +101,18 @@ describe('Le serveur des routes `/auth`', () => {
         });
     });
   });
+
+  describe('sur GET /auth/fcplus/deconnexion', () => {
+    it('vide le cookie de session', () => (
+      axios.get(`http://localhost:${port}/auth/fcplus/deconnexion`)
+        .then((reponse) => {
+          expect(reponse.headers).toHaveProperty('set-cookie');
+          const valeurEnteteSetCookie = reponse
+            .headers['set-cookie']
+            .find((h) => h.match(/jeton/));
+          expect(valeurEnteteSetCookie).toContain('jeton=;');
+        })
+        .catch(leveErreur)
+    ));
+  });
 });


### PR DESCRIPTION
… Pour gérer la destruction du jeton de session locale, une fois la session côté FC+ détruite.