### PR TITLE
Récupération du JWT associé au jeton de session FC+ et stockage dans le jeton de session locale

### DIFF
--- a/src/adaptateurs/adaptateurFranceConnectPlus.js
+++ b/src/adaptateurs/adaptateurFranceConnectPlus.js
@@ -4,6 +4,7 @@ const jose = require('jose');
 const adaptateurEnvironnement = require('./adaptateurEnvironnement');
 const adaptateurChiffrement = require('./adaptateurChiffrement');
 const { ErreurEchecAuthentification } = require('../erreurs');
+const SessionFCPlus = require('../modeles/sessionFCPlus');
 
 const configurationOpenIdFranceConnectPlus = axios
   .get(adaptateurEnvironnement.urlConfigurationOpenIdFCPlus())
@@ -22,25 +23,33 @@ const recupereJetonAcces = (code) => configurationOpenIdFranceConnectPlus
       { headers: { 'content-type': 'application/x-www-form-urlencoded' } },
     )
   ))
-  .then(({ data: { access_token: jetonAcces } }) => jetonAcces);
+  .then(({ data }) => jose.importJWK(adaptateurEnvironnement.clePriveeJWK())
+    .then((k) => jose.compactDecrypt(data.id_token, k))
+    .then(({ plaintext }) => new SessionFCPlus({
+      jetonAcces: data.access_token,
+      jwt: plaintext.toString(),
+    })));
 
-const recupereInfosUtilisateurChiffrees = (jeton) => configurationOpenIdFranceConnectPlus
+const recupereInfosUtilisateurChiffrees = (sessionFCPlus) => configurationOpenIdFranceConnectPlus
   .then(({ userinfo_endpoint: urlRecuperationInfosUtilisateur }) => (
     axios.get(
       urlRecuperationInfosUtilisateur,
-      { headers: { Authorization: `Bearer ${jeton}` } },
+      { headers: { Authorization: `Bearer ${sessionFCPlus.jetonAcces}` } },
     )
   ))
-  .then(({ data }) => data);
+  .then(({ data }) => sessionFCPlus.avecInfosUtilisateurChiffrees(data));
 
 const verifieSignatureJWT = (jwt) => configurationOpenIdFranceConnectPlus
   .then(({ jwks_uri: urlJWKS }) => jose.createRemoteJWKSet(new URL(urlJWKS)))
   .then((jwks) => adaptateurChiffrement.verifieJeton(jwt, jwks));
 
-const dechiffreInfosUtilisateur = (infos) => jose
+const dechiffreInfosUtilisateur = (sessionFCPlus) => jose
   .importJWK(adaptateurEnvironnement.clePriveeJWK())
-  .then((clePrivee) => jose.compactDecrypt(infos, clePrivee))
-  .then(({ plaintext }) => verifieSignatureJWT(plaintext));
+  .then((clePrivee) => jose.compactDecrypt(sessionFCPlus.infosUtilisateurChiffrees, clePrivee))
+  .then(({ plaintext }) => verifieSignatureJWT(plaintext))
+  .then((infosDechiffrees) => Object.assign(infosDechiffrees, {
+    jwtSessionFCPlus: sessionFCPlus.jwt,
+  }));
 
 const recupereInfosUtilisateur = (code) => recupereJetonAcces(code)
   .then(recupereInfosUtilisateurChiffrees)

--- a/src/modeles/sessionFCPlus.js
+++ b/src/modeles/sessionFCPlus.js
@@ -1,0 +1,14 @@
+class SessionFCPlus {
+  constructor(donnees) {
+    this.jetonAcces = donnees?.jetonAcces;
+    this.jwt = donnees?.jwt;
+    this.infosUtilisateurChiffrees = undefined;
+  }
+
+  avecInfosUtilisateurChiffrees(infos) {
+    this.infosUtilisateurChiffrees = infos;
+    return this;
+  }
+}
+
+module.exports = SessionFCPlus;

--- a/test/modeles/sessionFCPlus.spec.js
+++ b/test/modeles/sessionFCPlus.spec.js
@@ -1,0 +1,19 @@
+const SessionFCPlus = require('../../src/modeles/sessionFCPlus');
+
+describe('Une session FranceConnect+', () => {
+  it("connaît son jeton d'accès", () => {
+    const session = new SessionFCPlus({ jetonAcces: 'abcdef' });
+    expect(session.jetonAcces).toBe('abcdef');
+  });
+
+  it("connaît le JWT associé au jeton d'accès", () => {
+    const session = new SessionFCPlus({ jwt: 'abcdef' });
+    expect(session.jwt).toBe('abcdef');
+  });
+
+  it('ajoute les infos utilisateurs chiffrées', () => {
+    const session = new SessionFCPlus()
+      .avecInfosUtilisateurChiffrees('abcdef');
+    expect(session.infosUtilisateurChiffrees).toBe('abcdef');
+  });
+});


### PR DESCRIPTION
Note : actuellement, l'`AdaptateurFCPlus` dépend de l'objet métier `SessionFCPlus`. On inversera cette dépendance dans une PR à venir.