### PR TITLE
Inverse dépendance entre `SessionFCPlus` et `adaptateurFranceConnectPlus`

### DIFF
--- a/src/api/connexionFCPlus.js
+++ b/src/api/connexionFCPlus.js
@@ -1,13 +1,18 @@
+const SessionFCPlus = require('../modeles/sessionFCPlus');
+
 const connexionFCPlus = (config, code, requete, reponse) => {
   const { adaptateurChiffrement, adaptateurFranceConnectPlus } = config;
 
   requete.session.jeton = undefined;
 
-  return adaptateurFranceConnectPlus.recupereInfosUtilisateur(code)
+  const sessionFCPlus = new SessionFCPlus(
+    { adaptateurChiffrement, adaptateurFranceConnectPlus },
+    code,
+  );
+
+  return sessionFCPlus.enJSON()
     .then((infos) => adaptateurChiffrement.genereJeton(infos)
-      .then((jwt) => {
-        requete.session.jeton = jwt;
-      })
+      .then((jwt) => { requete.session.jeton = jwt; })
       .then(() => reponse.json(infos)))
     .catch((e) => reponse.status(502).json({ erreur: `Échec authentification (${e.message})` }));
 };

--- a/src/modeles/sessionFCPlus.js
+++ b/src/modeles/sessionFCPlus.js
@@ -1,13 +1,53 @@
+const { ErreurEchecAuthentification } = require('../erreurs');
+
 class SessionFCPlus {
-  constructor(donnees) {
-    this.jetonAcces = donnees?.jetonAcces;
-    this.jwt = donnees?.jwt;
-    this.infosUtilisateurChiffrees = undefined;
+  constructor(config, code) {
+    this.adaptateurChiffrement = config.adaptateurChiffrement;
+    this.adaptateurFranceConnectPlus = config.adaptateurFranceConnectPlus;
+    this.code = code;
+
+    this.jetonAcces = undefined;
+    this.jwt = undefined;
+    this.urlClefsPubliques = undefined;
   }
 
-  avecInfosUtilisateurChiffrees(infos) {
-    this.infosUtilisateurChiffrees = infos;
-    return this;
+  conserveJetonAcces(jetonAcces) {
+    this.jetonAcces = jetonAcces;
+  }
+
+  conserveJWT(jwe) {
+    return this.adaptateurChiffrement.dechiffreJWE(jwe)
+      .then((jwt) => { this.jwt = jwt; });
+  }
+
+  conserveURLClefsPubliques() {
+    return this.adaptateurFranceConnectPlus.recupereURLClefsPubliques()
+      .then((url) => { this.urlClefsPubliques = url; });
+  }
+
+  enJSON() {
+    return this.peupleDonneesJetonAcces()
+      .then(() => this.infosUtilisateurDechiffrees())
+      .then((jwtInfosUtilisateur) => this.adaptateurChiffrement.verifieSignatureJWTDepuisJWKS(
+        jwtInfosUtilisateur,
+        this.urlClefsPubliques,
+      ))
+      .then((infosDechiffrees) => Object.assign(infosDechiffrees, { jwtSessionFCPlus: this.jwt }))
+      .catch((e) => Promise.reject(new ErreurEchecAuthentification(e.message)));
+  }
+
+  infosUtilisateurDechiffrees() {
+    return this.adaptateurFranceConnectPlus.recupereInfosUtilisateurChiffrees(this.jetonAcces)
+      .then((jwe) => this.adaptateurChiffrement.dechiffreJWE(jwe));
+  }
+
+  peupleDonneesJetonAcces() {
+    return this.adaptateurFranceConnectPlus.recupereDonneesJetonAcces(this.code)
+      .then((donnees) => Promise.all([
+        this.conserveJetonAcces(donnees.access_token),
+        this.conserveJWT(donnees.id_token),
+        this.conserveURLClefsPubliques(),
+      ]));
   }
 }
 

--- a/test/modeles/sessionFCPlus.spec.js
+++ b/test/modeles/sessionFCPlus.spec.js
@@ -1,19 +1,146 @@
+const { ErreurEchecAuthentification } = require('../../src/erreurs');
 const SessionFCPlus = require('../../src/modeles/sessionFCPlus');
 
 describe('Une session FranceConnect+', () => {
-  it("connaît son jeton d'accès", () => {
-    const session = new SessionFCPlus({ jetonAcces: 'abcdef' });
-    expect(session.jetonAcces).toBe('abcdef');
+  const adaptateurChiffrement = {};
+  const adaptateurFranceConnectPlus = {};
+  const config = { adaptateurChiffrement, adaptateurFranceConnectPlus };
+
+  beforeEach(() => {
+    adaptateurChiffrement.dechiffreJWE = () => Promise.resolve('');
+    adaptateurChiffrement.verifieSignatureJWTDepuisJWKS = () => Promise.resolve({});
+    adaptateurFranceConnectPlus.recupereDonneesJetonAcces = () => Promise.resolve({});
+    adaptateurFranceConnectPlus.recupereInfosUtilisateurChiffrees = () => Promise.resolve('');
+    adaptateurFranceConnectPlus.recupereURLClefsPubliques = () => Promise.resolve('');
   });
 
-  it("connaît le JWT associé au jeton d'accès", () => {
-    const session = new SessionFCPlus({ jwt: 'abcdef' });
-    expect(session.jwt).toBe('abcdef');
+  describe('sur demande peuplement donnees jeton accès', () => {
+    it("conserve le jeton d'accès", () => {
+      adaptateurFranceConnectPlus.recupereDonneesJetonAcces = (code) => {
+        try {
+          expect(code).toBe('unCode');
+          return Promise.resolve({ access_token: 'abcdef' });
+        } catch (e) {
+          return Promise.reject(e);
+        }
+      };
+
+      const session = new SessionFCPlus(config, 'unCode');
+      return session.peupleDonneesJetonAcces()
+        .then(() => {
+          expect(session.jetonAcces).toBe('abcdef');
+        });
+    });
+
+    it('conserve le JWT associé', () => {
+      adaptateurFranceConnectPlus.recupereDonneesJetonAcces = () => Promise.resolve({ id_token: '123' });
+      adaptateurChiffrement.dechiffreJWE = (jwe) => {
+        try {
+          expect(jwe).toBe('123');
+          return Promise.resolve('999');
+        } catch (e) {
+          return Promise.reject(e);
+        }
+      };
+
+      const session = new SessionFCPlus(config, 'unCode');
+      return session.peupleDonneesJetonAcces()
+        .then(() => {
+          expect(session.jwt).toBe('999');
+        });
+    });
+
+    it("conserve l'URL des clefs publiques FC+", () => {
+      adaptateurFranceConnectPlus.recupereURLClefsPubliques = () => Promise.resolve('http://example.com');
+
+      const session = new SessionFCPlus(config, 'unCode');
+      return session.peupleDonneesJetonAcces()
+        .then(() => {
+          expect(session.urlClefsPubliques).toBe('http://example.com');
+        });
+    });
   });
 
-  it('ajoute les infos utilisateurs chiffrées', () => {
-    const session = new SessionFCPlus()
-      .avecInfosUtilisateurChiffrees('abcdef');
-    expect(session.infosUtilisateurChiffrees).toBe('abcdef');
+  describe('sur demande infos utilisateur déchiffrées', () => {
+    it('récupère les infos', () => {
+      adaptateurFranceConnectPlus.recupereInfosUtilisateurChiffrees = (jetonAcces) => {
+        try {
+          expect(jetonAcces).toBe('abcdef');
+          return Promise.resolve('123');
+        } catch (e) {
+          return Promise.reject(e);
+        }
+      };
+
+      adaptateurChiffrement.dechiffreJWE = (jwe) => {
+        try {
+          expect(jwe).toBe('123');
+          return Promise.resolve('999');
+        } catch (e) {
+          return Promise.reject(e);
+        }
+      };
+
+      const session = new SessionFCPlus(config, 'unCode');
+      session.conserveJetonAcces('abcdef');
+
+      return session.infosUtilisateurDechiffrees()
+        .then((jwt) => {
+          expect(jwt).toBe('999');
+        });
+    });
+  });
+
+  describe('sur demande description données', () => {
+    it('vérifie la signature du JWT des infos utilisateur', () => {
+      let signatureVerifiee = false;
+      adaptateurChiffrement.verifieSignatureJWTDepuisJWKS = () => {
+        signatureVerifiee = true;
+        return Promise.resolve({});
+      };
+
+      const session = new SessionFCPlus(config, 'unCode');
+      return session.enJSON()
+        .then(() => expect(signatureVerifiee).toBe(true));
+    });
+
+    it('ajoute le JWT de session aux infos utilisateur', () => {
+      adaptateurFranceConnectPlus.recupereURLClefsPubliques = () => Promise.resolve('http://example.com');
+      adaptateurFranceConnectPlus.recupereDonneesJetonAcces = () => Promise.resolve({ id_token: '999' });
+      adaptateurFranceConnectPlus.recupereInfosUtilisateurChiffrees = () => Promise.resolve('aaa');
+      adaptateurChiffrement.dechiffreJWE = (jwe) => Promise.resolve(jwe);
+      adaptateurChiffrement.verifieSignatureJWTDepuisJWKS = (jwt, url) => {
+        try {
+          expect(jwt).toBe('aaa');
+          expect(url).toBe('http://example.com');
+          return Promise.resolve({ uneClef: 'uneValeur' });
+        } catch (e) {
+          return Promise.reject(e);
+        }
+      };
+
+      const session = new SessionFCPlus(config, 'unCode');
+      session.jwt = '999';
+
+      return session.enJSON()
+        .then((json) => expect(json).toEqual({
+          uneClef: 'uneValeur',
+          jwtSessionFCPlus: '999',
+        }));
+    });
+
+    it('lève une `ErreurEchecAuthentification` si une erreur est rencontrée', () => {
+      expect.assertions(2);
+
+      adaptateurFranceConnectPlus.recupereInfosUtilisateurChiffrees = () => Promise.reject(new Error('oups'));
+
+      const session = new SessionFCPlus(config, 'unCode');
+
+      return session.enJSON()
+        .catch((e) => {
+          expect(e).toBeInstanceOf(ErreurEchecAuthentification);
+          expect(e.message).toBe('oups');
+        });
+    });
   });
 });

--- a/test/routes/serveurTest.js
+++ b/test/routes/serveurTest.js
@@ -22,8 +22,10 @@ const serveurTest = () => {
 
   const initialise = (suite) => {
     adaptateurChiffrement = {
+      dechiffreJWE: () => Promise.resolve(),
       genereJeton: () => Promise.resolve(),
       verifieJeton: () => Promise.resolve(),
+      verifieSignatureJWTDepuisJWKS: () => Promise.resolve({}),
     };
 
     adaptateurDomibus = {
@@ -40,7 +42,9 @@ const serveurTest = () => {
     };
 
     adaptateurFranceConnectPlus = {
-      recupereInfosUtilisateur: () => Promise.resolve({}),
+      recupereDonneesJetonAcces: () => Promise.resolve({}),
+      recupereInfosUtilisateurChiffrees: () => Promise.resolve(),
+      recupereURLClefsPubliques: () => Promise.resolve(),
     };
 
     adaptateurUUID = {


### PR DESCRIPTION
On peut ainsi mieux tester les interactions entre OOTS-France et FranceConnect+ et limiter le comportement de l'adaptateur aux appels réseaux.