### PR TITLE
Destruction de la session FC+ depuis un lien « Se déconnecter » sur la page d'accueil

### DIFF
--- a/.env.oots.template
+++ b/.env.oots.template
@@ -16,6 +16,7 @@ SECRET_JETON_SESSION= # secret utilisé pour chiffrer et déchiffrer le jeton st
 IDENTIFIANT_EIDAS= # identifiant eIDAS injecté dans les requêtes (tant qu'on ne sait pas le récupérer)
 URL_OOTS_FRANCE= # URL Serveur OOTS-France, ex. https://oots.gouv.fr
 URL_REDIRECTION_CONNEXION= # URL redirection après authentification FranceConnect+
+URL_REDIRECTION_DECONNEXION= # URL redirection après destruction session FranceConnect+
 
 LOGIN_API_REST= # Login utilisé pour accéder à l'API REST de DOMIBUS
 MOT_DE_PASSE_API_REST= # Mot de passe utilisé pour accéder à l'API REST de DOMIBUS

--- a/src/adaptateurs/adaptateurEnvironnement.js
+++ b/src/adaptateurs/adaptateurEnvironnement.js
@@ -16,6 +16,8 @@ const secretJetonSession = () => new TextEncoder().encode(process.env.SECRET_JET
 
 const urlConfigurationOpenIdFCPlus = () => process.env.URL_CONFIGURATION_OPEN_ID_FCPLUS;
 
+const urlRedirectionDeconnexion = () => process.env.URL_REDIRECTION_DECONNEXION;
+
 module.exports = {
   avecEnvoiCookieSurHTTP,
   avecRequetePieceJustificative,
@@ -24,4 +26,5 @@ module.exports = {
   parametresRequeteJeton,
   secretJetonSession,
   urlConfigurationOpenIdFCPlus,
+  urlRedirectionDeconnexion,
 };

--- a/src/adaptateurs/adaptateurFranceConnectPlus.js
+++ b/src/adaptateurs/adaptateurFranceConnectPlus.js
@@ -32,8 +32,12 @@ const recupereInfosUtilisateurChiffrees = (jetonAcces) => configurationOpenIdFra
 const recupereURLClefsPubliques = () => configurationOpenIdFranceConnectPlus
   .then(({ jwks_uri: url }) => url);
 
+const urlDestructionSession = () => configurationOpenIdFranceConnectPlus
+  .then(({ end_session_endpoint: url }) => url);
+
 module.exports = {
   recupereDonneesJetonAcces,
   recupereInfosUtilisateurChiffrees,
   recupereURLClefsPubliques,
+  urlDestructionSession,
 };

--- a/src/api/destructionSessionFCPlus.js
+++ b/src/api/destructionSessionFCPlus.js
@@ -1,0 +1,18 @@
+const destructionSessionFCPlus = (config, requete, reponse) => {
+  const {
+    adaptateurChiffrement,
+    adaptateurEnvironnement,
+    adaptateurFranceConnectPlus,
+  } = config;
+
+  const { utilisateurCourant: { jwtSessionFCPlus } } = requete;
+  const etat = adaptateurChiffrement.cleHachage(`${Math.random()}`);
+  const urlRedirectionDeconnexion = adaptateurEnvironnement.urlRedirectionDeconnexion();
+
+  adaptateurFranceConnectPlus.urlDestructionSession()
+    .then((url) => reponse.redirect(
+      `${url}?id_token_hint=${jwtSessionFCPlus}&state=${etat}&post_logout_redirect_uri=${urlRedirectionDeconnexion}`,
+    ));
+};
+
+module.exports = destructionSessionFCPlus;

--- a/src/ootsFrance.js
+++ b/src/ootsFrance.js
@@ -38,6 +38,7 @@ const creeServeur = (config) => {
     adaptateurChiffrement,
     adaptateurEnvironnement,
     adaptateurFranceConnectPlus,
+    middleware,
   }));
 
   app.use('/ebms', routesEbms({ adaptateurUUID, horodateur }));

--- a/src/routes/routesAuth.js
+++ b/src/routes/routesAuth.js
@@ -2,9 +2,15 @@ const express = require('express');
 
 const connexionFCPlus = require('../api/connexionFCPlus');
 const deconnexionFCPlus = require('../api/deconnexionFCPlus');
+const destructionSessionFCPlus = require('../api/destructionSessionFCPlus');
 
 const routesAuth = (config) => {
-  const { adaptateurChiffrement, adaptateurEnvironnement, adaptateurFranceConnectPlus } = config;
+  const {
+    adaptateurChiffrement,
+    adaptateurEnvironnement,
+    adaptateurFranceConnectPlus,
+    middleware,
+  } = config;
 
   const routes = express.Router();
 
@@ -45,6 +51,18 @@ const routesAuth = (config) => {
 
   routes.get('/fcplus/deconnexion', (requete, reponse) => (
     deconnexionFCPlus(requete, reponse)
+  ));
+
+  routes.get('/fcplus/destructionSession', (...args) => middleware.renseigneUtilisateurCourant(...args), (requete, reponse) => (
+    destructionSessionFCPlus(
+      {
+        adaptateurChiffrement,
+        adaptateurEnvironnement,
+        adaptateurFranceConnectPlus,
+      },
+      requete,
+      reponse,
+    )
   ));
 
   return routes;

--- a/src/routes/routesBase.js
+++ b/src/routes/routesBase.js
@@ -10,9 +10,16 @@ const routesBase = (config) => {
     (requete, reponse) => {
       const infosUtilisateur = requete.utilisateurCourant;
       const message = infosUtilisateur
-        ? `Utilisateur courant : ${infosUtilisateur.given_name} ${infosUtilisateur.family_name}`
+        ? `
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>OOTS-France</title>
+<p>Utilisateur courant : ${infosUtilisateur.given_name} ${infosUtilisateur.family_name}</p>
+<a href="/auth/fcplus/destructionSession">Déconnexion</a>
+`
         : "Pas d'utilisateur courant";
 
+      reponse.set('Content-Type', 'text/html');
       reponse.send(message);
     },
   );

--- a/test/api/destructionSessionFCPlus.spec.js
+++ b/test/api/destructionSessionFCPlus.spec.js
@@ -1,0 +1,89 @@
+const destructionSessionFCPlus = require('../../src/api/destructionSessionFCPlus');
+
+describe('Le requêteur de destruction de session FC+', () => {
+  const adaptateurChiffrement = {};
+  const adaptateurEnvironnement = {};
+  const adaptateurFranceConnectPlus = {};
+  const config = { adaptateurChiffrement, adaptateurEnvironnement, adaptateurFranceConnectPlus };
+  const requete = {};
+  const reponse = {};
+
+  beforeEach(() => {
+    adaptateurChiffrement.cleHachage = () => '';
+    adaptateurEnvironnement.urlRedirectionDeconnexion = () => '';
+    adaptateurFranceConnectPlus.urlDestructionSession = () => Promise.resolve('');
+    requete.session = {};
+    reponse.end = () => Promise.resolve();
+    reponse.redirect = () => Promise.resolve();
+  });
+
+  describe('quand le JWT de session FC+ existe', () => {
+    beforeEach(() => {
+      requete.utilisateurCourant = { jwtSessionFCPlus: '' };
+    });
+
+    it('redirige vers serveur FC+', () => {
+      expect.assertions(1);
+      adaptateurFranceConnectPlus.urlDestructionSession = () => Promise.resolve('http://example.com');
+
+      reponse.redirect = (url) => {
+        try {
+          expect(url).toMatch(/^http:\/\/example\.com\?/);
+          return Promise.resolve();
+        } catch (e) {
+          return Promise.reject(e);
+        }
+      };
+
+      destructionSessionFCPlus(config, requete, reponse);
+    });
+
+    it('récupère le JWT de session FC+ stocké dans la session locale', () => {
+      expect.assertions(1);
+
+      requete.utilisateurCourant = { jwtSessionFCPlus: 'abcdef' };
+      reponse.redirect = (url) => {
+        try {
+          expect(url).toContain('id_token_hint=abcdef');
+          return Promise.resolve();
+        } catch (e) {
+          return Promise.reject(e);
+        }
+      };
+
+      destructionSessionFCPlus(config, requete, reponse);
+    });
+
+    it('ajoute un état en paramètre de la requête', () => {
+      expect.assertions(1);
+      adaptateurChiffrement.cleHachage = () => '12345';
+
+      reponse.redirect = (url) => {
+        try {
+          expect(url).toContain('state=12345');
+          return Promise.resolve();
+        } catch (e) {
+          return Promise.reject(e);
+        }
+      };
+
+      destructionSessionFCPlus(config, requete, reponse);
+    });
+
+    it("ajoute l'URL de redirection post-logout en paramètre de la requête", () => {
+      expect.assertions(1);
+      adaptateurEnvironnement.urlRedirectionDeconnexion = () => 'http://example.com';
+
+      reponse.redirect = (url) => {
+        try {
+          expect(url).toContain('post_logout_redirect_uri=http://example.com');
+          return Promise.resolve();
+        } catch (e) {
+          return Promise.reject(e);
+        }
+      };
+
+      destructionSessionFCPlus(config, requete, reponse);
+    });
+  });
+});

--- a/test/routes/routesAuth.spec.js
+++ b/test/routes/routesAuth.spec.js
@@ -108,4 +108,18 @@ describe('Le serveur des routes `/auth`', () => {
         .catch(leveErreur)
     ));
   });
+
+  describe('sur GET /auth/fcplus/destructionSession', () => {
+    it("appelle le middleware pour renseigner les infos de l'utilisateur courant", () => {
+      serveur.middleware().reinitialise({
+        utilisateurCourant: { given_name: '', family_name: '', jwtSessionFCPlus: 'abcdef' },
+      });
+
+      serveur.adaptateurFranceConnectPlus().urlDestructionSession = () => Promise.resolve(`http://localhost:${port}`);
+
+      return axios.get(`http://localhost:${port}/auth/fcplus/destructionSession`)
+        .then((reponse) => expect(reponse.request.path).toContain('id_token_hint=abcdef'))
+        .catch(leveErreur);
+    });
+  });
 });

--- a/test/routes/serveurTest.js
+++ b/test/routes/serveurTest.js
@@ -22,6 +22,7 @@ const serveurTest = () => {
 
   const initialise = (suite) => {
     adaptateurChiffrement = {
+      cleHachage: () => '',
       dechiffreJWE: () => Promise.resolve(),
       genereJeton: () => Promise.resolve(),
       verifieJeton: () => Promise.resolve(),
@@ -39,12 +40,14 @@ const serveurTest = () => {
       avecRequetePieceJustificative: () => true,
       identifiantEIDAS: () => 'FR/BE/123456789',
       secretJetonSession: () => 'secret',
+      urlRedirectionDeconnexion: () => '',
     };
 
     adaptateurFranceConnectPlus = {
       recupereDonneesJetonAcces: () => Promise.resolve({}),
       recupereInfosUtilisateurChiffrees: () => Promise.resolve(),
       recupereURLClefsPubliques: () => Promise.resolve(),
+      urlDestructionSession: () => Promise.resolve(''),
     };
 
     adaptateurUUID = {


### PR DESCRIPTION
Dans cette PR :
- on ajoute une route `GET /auth/fcplus/destructionSession`
- on récupère le JWT de session FC+ stocké en session locale
- on forme l'URL de la requête à FC+
- on ajoute un lien sur la page d'accueil pour pouvoir tester la déconnexion

Il faudra penser à renseigner la variable d'environnement `URL_REDIRECTION_DECONNEXION` dans l'environnement de préprod avant de déployer.

Prochaines étapes :
- traiter le cas où on appelle `/auth/fcplus/destructionSession` alors qu'il n'y a pas d'utilisateur courant
- injecter une _factory_ de `SessionFCPlus` pour à la fois récupérer un objet complètement initialisé et pouvoir utiliser des mocks de `SessionFCPlus` dans les tests.
