### PR TITLE
[NETTOYAGE] Introduction fabrique de session FC+

### DIFF
--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ const AdaptateurDomibus = require('./src/adaptateurs/adaptateurDomibus');
 const adaptateurEnvironnement = require('./src/adaptateurs/adaptateurEnvironnement');
 const adaptateurFranceConnectPlus = require('./src/adaptateurs/adaptateurFranceConnectPlus');
 const adaptateurUUID = require('./src/adaptateurs/adaptateurUUID');
+const FabriqueSessionFCPlus = require('./src/modeles/fabriqueSessionFCPlus');
 const horodateur = require('./src/adaptateurs/horodateur');
 const DepotPointsAcces = require('./src/depots/depotPointsAcces');
 const Middleware = require('./src/routes/middleware');
@@ -12,6 +13,10 @@ const Middleware = require('./src/routes/middleware');
 const adaptateurDomibus = AdaptateurDomibus({ adaptateurUUID, horodateur });
 const depotPointsAcces = new DepotPointsAcces(adaptateurDomibus);
 const ecouteurDomibus = new EcouteurDomibus({ adaptateurDomibus, intervalleEcoute: 1000 });
+const fabriqueSessionFCPlus = new FabriqueSessionFCPlus({
+  adaptateurChiffrement,
+  adaptateurFranceConnectPlus,
+});
 const middleware = new Middleware({ adaptateurChiffrement, adaptateurEnvironnement });
 
 const serveur = OOTS_FRANCE.creeServeur({
@@ -22,6 +27,7 @@ const serveur = OOTS_FRANCE.creeServeur({
   adaptateurUUID,
   depotPointsAcces,
   ecouteurDomibus,
+  fabriqueSessionFCPlus,
   horodateur,
   middleware,
 });

--- a/src/api/connexionFCPlus.js
+++ b/src/api/connexionFCPlus.js
@@ -1,16 +1,10 @@
-const SessionFCPlus = require('../modeles/sessionFCPlus');
-
 const connexionFCPlus = (config, code, requete, reponse) => {
-  const { adaptateurChiffrement, adaptateurFranceConnectPlus } = config;
+  const { adaptateurChiffrement, fabriqueSessionFCPlus } = config;
 
   requete.session.jeton = undefined;
 
-  const sessionFCPlus = new SessionFCPlus(
-    { adaptateurChiffrement, adaptateurFranceConnectPlus },
-    code,
-  );
-
-  return sessionFCPlus.enJSON()
+  return fabriqueSessionFCPlus.nouvelleSession(code)
+    .then((session) => session.enJSON())
     .then((infos) => adaptateurChiffrement.genereJeton(infos)
       .then((jwt) => { requete.session.jeton = jwt; })
       .then(() => reponse.json(infos)))

--- a/src/modeles/fabriqueSessionFCPlus.js
+++ b/src/modeles/fabriqueSessionFCPlus.js
@@ -1,0 +1,36 @@
+const SessionFCPlus = require('./sessionFCPlus');
+
+class FabriqueSessionFCPlus {
+  constructor(config) {
+    this.config = config;
+    this.adaptateurChiffrement = config.adaptateurChiffrement;
+    this.adaptateurFranceConnectPlus = config.adaptateurFranceConnectPlus;
+  }
+
+  peupleDonneesJetonAcces(code) {
+    const conserveJetonAcces = (jetonAcces) => { this.session.jetonAcces = jetonAcces; };
+
+    const conserveJWT = (jwe) => this.adaptateurChiffrement
+      .dechiffreJWE(jwe)
+      .then((jwt) => { this.session.jwt = jwt; });
+
+    const conserveURLClefsPubliques = () => this.adaptateurFranceConnectPlus
+      .recupereURLClefsPubliques()
+      .then((url) => { this.session.urlClefsPubliques = url; });
+
+    return this.adaptateurFranceConnectPlus.recupereDonneesJetonAcces(code)
+      .then((donnees) => Promise.all([
+        conserveJetonAcces(donnees.access_token),
+        conserveJWT(donnees.id_token),
+        conserveURLClefsPubliques(),
+      ]));
+  }
+
+  nouvelleSession(code) {
+    this.session = new SessionFCPlus(this.config);
+    return this.peupleDonneesJetonAcces(code)
+      .then(() => this.session);
+  }
+}
+
+module.exports = FabriqueSessionFCPlus;

--- a/src/ootsFrance.js
+++ b/src/ootsFrance.js
@@ -16,6 +16,7 @@ const creeServeur = (config) => {
     adaptateurUUID,
     depotPointsAcces,
     ecouteurDomibus,
+    fabriqueSessionFCPlus,
     horodateur,
     middleware,
   } = config;
@@ -38,6 +39,7 @@ const creeServeur = (config) => {
     adaptateurChiffrement,
     adaptateurEnvironnement,
     adaptateurFranceConnectPlus,
+    fabriqueSessionFCPlus,
     middleware,
   }));
 

--- a/src/routes/routesAuth.js
+++ b/src/routes/routesAuth.js
@@ -9,6 +9,7 @@ const routesAuth = (config) => {
     adaptateurChiffrement,
     adaptateurEnvironnement,
     adaptateurFranceConnectPlus,
+    fabriqueSessionFCPlus,
     middleware,
   } = config;
 
@@ -41,7 +42,7 @@ const routesAuth = (config) => {
       reponse.status(400).json({ erreur: "Paramètre 'code' absent de la requête" });
     } else {
       connexionFCPlus(
-        { adaptateurChiffrement, adaptateurFranceConnectPlus },
+        { adaptateurChiffrement, fabriqueSessionFCPlus },
         code,
         requete,
         reponse,

--- a/test/modeles/fabriqueSessionFCPlus.spec.js
+++ b/test/modeles/fabriqueSessionFCPlus.spec.js
@@ -1,0 +1,52 @@
+const FabriqueSessionFCPlus = require('../../src/modeles/fabriqueSessionFCPlus');
+
+describe('La fabrique de session FC+', () => {
+  const adaptateurChiffrement = {};
+  const adaptateurFranceConnectPlus = {};
+  const config = { adaptateurChiffrement, adaptateurFranceConnectPlus };
+
+  beforeEach(() => {
+    adaptateurChiffrement.dechiffreJWE = () => Promise.resolve('');
+    adaptateurFranceConnectPlus.recupereDonneesJetonAcces = () => Promise.resolve({});
+    adaptateurFranceConnectPlus.recupereURLClefsPubliques = () => Promise.resolve('');
+  });
+
+  it("conserve le jeton d'accès", () => {
+    adaptateurFranceConnectPlus.recupereDonneesJetonAcces = (code) => {
+      try {
+        expect(code).toBe('unCode');
+        return Promise.resolve({ access_token: 'abcdef' });
+      } catch (e) {
+        return Promise.reject(e);
+      }
+    };
+
+    const fabrique = new FabriqueSessionFCPlus(config);
+    return fabrique.nouvelleSession('unCode')
+      .then((session) => expect(session.jetonAcces).toBe('abcdef'));
+  });
+
+  it('conserve le JWT de la session FC+', () => {
+    adaptateurFranceConnectPlus.recupereDonneesJetonAcces = () => Promise.resolve({ id_token: '123' });
+    adaptateurChiffrement.dechiffreJWE = (jwe) => {
+      try {
+        expect(jwe).toBe('123');
+        return Promise.resolve('999');
+      } catch (e) {
+        return Promise.reject(e);
+      }
+    };
+
+    const fabrique = new FabriqueSessionFCPlus(config);
+    return fabrique.nouvelleSession('unCode')
+      .then((session) => expect(session.jwt).toBe('999'));
+  });
+
+  it("conserve l'URL des clefs publiques FC+", () => {
+    adaptateurFranceConnectPlus.recupereURLClefsPubliques = () => Promise.resolve('http://example.com');
+
+    const fabrique = new FabriqueSessionFCPlus(config);
+    return fabrique.nouvelleSession('unCode')
+      .then((session) => expect(session.urlClefsPubliques).toBe('http://example.com'));
+  });
+});

--- a/test/routes/serveurTest.js
+++ b/test/routes/serveurTest.js
@@ -11,6 +11,7 @@ const serveurTest = () => {
   let adaptateurUUID;
   let depotPointsAcces;
   let ecouteurDomibus;
+  let fabriqueSessionFCPlus;
   let horodateur;
   let middleware;
 
@@ -64,6 +65,10 @@ const serveurTest = () => {
       etat: () => '',
     };
 
+    fabriqueSessionFCPlus = {
+      nouvelleSession: () => Promise.resolve({ enJSON: () => Promise.resolve({}) }),
+    };
+
     horodateur = {
       maintenant: () => '',
     };
@@ -78,6 +83,7 @@ const serveurTest = () => {
       adaptateurUUID,
       depotPointsAcces,
       ecouteurDomibus,
+      fabriqueSessionFCPlus,
       horodateur,
       middleware,
     });
@@ -96,6 +102,7 @@ const serveurTest = () => {
     arrete,
     depotPointsAcces: () => depotPointsAcces,
     ecouteurDomibus: () => ecouteurDomibus,
+    fabriqueSessionFCPlus: () => fabriqueSessionFCPlus,
     horodateur: () => horodateur,
     initialise,
     middleware: () => middleware,


### PR DESCRIPTION
Cela permet de
- mieux contrôler le processus d'instanciation (et de détection de problème d'instanciation)
- bouchonner la session dans le requêteur de connexion FC+