### PR TITLE
[CORRECTION] Mise à jour du comportement du serveur mock FC+

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,3 +1,4 @@
 PORT_DOMIBUS= # port d'accès à la console Domibus (depuis la machine hôte)
 PORT_MOCK_FCPLUS= # port d'accès au mock FC plus
 PORT_OOTS_FRANCE= # port sur lequel le serveur écoute
+URL_BASE= # URL du serveur sur lequel les conteneurs sont instanciés (ex. https://example.com)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
     ports:
       - "${PORT_MOCK_FCPLUS}:4000"
     environment:
-      - URL_BASE_MOCK_FCPLUS=http://mock_fcplus:4000
+      - URL_BASE_MOCK_FCPLUS=${URL_BASE}:${PORT_MOCK_FCPLUS}
 
   domibus:
     image: code.europa.eu:4567/edelivery/docker/domibus-tomcat9:5.0.4

--- a/mockFCPlus.js
+++ b/mockFCPlus.js
@@ -66,16 +66,23 @@ app.use(express.urlencoded({ extended: true }));
 
 app.get('/', (_requete, reponse) => {
   reponse.json({
+    end_session_endpoint: `${process.env.URL_BASE_MOCK_FCPLUS}/fin_session`,
     jwks_uri: `${process.env.URL_BASE_MOCK_FCPLUS}/jwks`,
     token_endpoint: `${process.env.URL_BASE_MOCK_FCPLUS}/jeton`,
     userinfo_endpoint: `${process.env.URL_BASE_MOCK_FCPLUS}/userinfo`,
   });
 });
 
+app.get('/fin_session', (_requete, reponse) => {
+  reponse.redirect(process.env.URL_REDIRECTION_DECONNEXION);
+});
+
 app.post('/jeton', (requete, reponse) => {
   const { code } = requete.body;
   const jeton = (code === 'XXX') ? JETON_CAS_SIGNATURE_INVALIDE : 'unJeton';
-  reponse.json({ access_token: jeton });
+
+  enJWE(jwkValide, {})
+    .then((jwe) => reponse.json({ access_token: jeton, id_token: jwe }));
 });
 
 app.get('/jwks', (_requete, reponse) => {


### PR DESCRIPTION
Depuis l'implémentation de la fonction de déconnexion, le comportement du serveur mock n'était plus en accord avec celui attendu par le code du serveur OOTS.

Cette PR corrige un double problème en…
- ajoutant un point d'accès à la destruction d'une session
- renvoyant un `id_token` dans les informations du jeton d'accès